### PR TITLE
API Key Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>

--- a/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
+++ b/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
@@ -2,15 +2,19 @@ package org.folio.edge.core;
 
 import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 
 import org.apache.log4j.Logger;
 import org.folio.edge.core.cache.TokenCache;
 import org.folio.edge.core.cache.TokenCache.NotInitializedException;
+import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.utils.OkapiClient;
 
 public class InstitutionalUserHelper {
   private static final Logger logger = Logger.getLogger(InstitutionalUserHelper.class);
+
+  public static final Pattern DELIM = Pattern.compile("_");
 
   private final SecureStore secureStore;
 
@@ -18,19 +22,28 @@ public class InstitutionalUserHelper {
     this.secureStore = secureStore;
   }
 
-  public String getTenant(String apiKey) {
-    String tenant = null;
+  public static ClientInfo parseApiKey(String apiKey) throws MalformedApiKeyException {
+    ClientInfo ret = null;
     try {
-      tenant = new String(Base64.getUrlDecoder().decode(apiKey.getBytes()));
-      logger.info(String.format("API Key: %s, Tenant: %s", apiKey, tenant));
+      String decoded = new String(Base64.getUrlDecoder().decode(apiKey.getBytes()));
+      String[] parts = DELIM.split(decoded);
+
+      ret = new ClientInfo(parts[0], parts[1], parts[2]);
+
+      logger.info(String.format("API Key: %s, Tenant: %s Username: %s", apiKey, ret.tenantId, ret.username));
 
     } catch (Exception e) {
       logger.error(String.format("Failed to parse API Key %s", apiKey), e);
+      throw new MalformedApiKeyException(e);
     }
-    return tenant;
+
+    if (ret.tenantId == null) {
+      throw new MalformedApiKeyException("Null Tenant");
+    }
+    return ret;
   }
 
-  public CompletableFuture<String> getToken(OkapiClient client, String tenant, String username) {
+  public CompletableFuture<String> getToken(OkapiClient client, String clientId, String tenant, String username) {
     CompletableFuture<String> future = new CompletableFuture<>();
 
     String token = null;
@@ -45,7 +58,7 @@ public class InstitutionalUserHelper {
       logger.info("Using cached token");
       future.complete(token);
     } else {
-      String password = secureStore.get(tenant, username);
+      String password = secureStore.get(clientId, tenant, username);
 
       CompletableFuture<String> loginFuture = client.login(username, password);
 
@@ -70,4 +83,18 @@ public class InstitutionalUserHelper {
 
     return future;
   }
+
+  public static class MalformedApiKeyException extends Exception {
+
+    private static final long serialVersionUID = 7852873967223950947L;
+
+    public MalformedApiKeyException(Throwable t) {
+      super(t);
+    }
+
+    public MalformedApiKeyException(String msg) {
+      super(msg);
+    }
+  }
+
 }

--- a/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
+++ b/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
@@ -16,7 +16,7 @@ public class InstitutionalUserHelper {
 
   public static final Pattern DELIM = Pattern.compile("_");
 
-  private final SecureStore secureStore;
+  protected final SecureStore secureStore;
 
   public InstitutionalUserHelper(SecureStore secureStore) {
     this.secureStore = secureStore;

--- a/src/main/java/org/folio/edge/core/model/ClientInfo.java
+++ b/src/main/java/org/folio/edge/core/model/ClientInfo.java
@@ -1,0 +1,15 @@
+package org.folio.edge.core.model;
+
+public class ClientInfo {
+
+  public final String tenantId;
+  public final String username;
+  public final String clientId;
+
+  public ClientInfo(String clientId, String tenantId, String username) {
+    this.tenantId = tenantId;
+    this.username = username;
+    this.clientId = clientId;
+  }
+
+}

--- a/src/main/java/org/folio/edge/core/security/AwsParamStore.java
+++ b/src/main/java/org/folio/edge/core/security/AwsParamStore.java
@@ -79,10 +79,10 @@ public class AwsParamStore extends SecureStore {
   }
 
   @Override
-  public String get(String tenant, String username) {
+  public String get(String clientId, String tenant, String username) {
     String ret = null;
 
-    String key = String.format("%s_%s", tenant, username);
+    String key = String.format("%s_%s_%s", clientId, tenant, username);
     GetParameterRequest req = new GetParameterRequest()
       .withName(key)
       .withWithDecryption(true);

--- a/src/main/java/org/folio/edge/core/security/EphemeralStore.java
+++ b/src/main/java/org/folio/edge/core/security/EphemeralStore.java
@@ -39,7 +39,8 @@ public class EphemeralStore extends SecureStore {
   }
 
   @Override
-  public String get(String tenant, String username) {
+  public String get(String clientId, String tenant, String username) {
+    // NOTE: ignore clientId
     return store.get(getKey(tenant, username));
   }
 

--- a/src/main/java/org/folio/edge/core/security/SecureStore.java
+++ b/src/main/java/org/folio/edge/core/security/SecureStore.java
@@ -10,6 +10,6 @@ public abstract class SecureStore {
     this.properties = properties;
   }
 
-  public abstract String get(String tenant, String username);
+  public abstract String get(String clientId, String tenant, String username);
 
 }

--- a/src/main/java/org/folio/edge/core/security/VaultStore.java
+++ b/src/main/java/org/folio/edge/core/security/VaultStore.java
@@ -71,12 +71,12 @@ public class VaultStore extends SecureStore {
   }
 
   @Override
-  public String get(String tenant, String username) {
+  public String get(String clientId, String tenant, String username) {
     String ret = null;
 
     try {
       ret = vault.logical()
-        .read("secret/" + tenant)
+        .read(String.format("%s/%s", clientId, tenant))
         .getData()
         .get(username);
     } catch (VaultException e) {

--- a/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
@@ -134,10 +134,11 @@ public class AwsParamStoreTest {
   @Test
   public void testGetFound() {
     // test data & expected values
+    String clientId = "ditdatdot";
     String tenant = "foo";
     String user = "bar";
     String val = "letmein";
-    String key = tenant + "_" + user;
+    String key = String.format("%s_%s_%s", clientId, tenant, user);
 
     // setup mocks/spys/etc.
     GetParameterRequest req = new GetParameterRequest().withName(key).withWithDecryption(true);
@@ -145,19 +146,19 @@ public class AwsParamStoreTest {
     when(ssm.getParameter(req)).thenReturn(resp);
 
     // test & assertions
-    assertEquals(val, secureStore.get(tenant, user));
+    assertEquals(val, secureStore.get(clientId, tenant, user));
   }
 
   @Test
   public void testGetNotFound() {
     String exceptionMsg = "Parameter null_null not found. (Service: AWSSimpleSystemsManagement; Status Code: 400; Error Code: ParameterNotFound; Request ID: 25fc4a22-9839-4645-b7b4-ad40aa643821)";
-    String logMsg = "Exception retreiving password for null_null: ";
+    String logMsg = "Exception retreiving password for null_null_null: ";
     Throwable exception = new AWSSimpleSystemsManagementException(exceptionMsg);
 
     when(ssm.getParameter(any())).thenThrow(exception);
 
     TestUtils.assertLogMessage(AwsParamStore.logger, 1, 1, Level.ERROR, logMsg, exception, () -> {
-      String val = secureStore.get(null, null);
+      String val = secureStore.get(null, null, null);
       assertNull(val);
     });
   }

--- a/src/test/java/org/folio/edge/core/security/EphemeralStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/EphemeralStoreTest.java
@@ -41,11 +41,11 @@ public class EphemeralStoreTest {
   @Test
   public void testGet() {
     assertEquals(4, store.store.size());
-    assertEquals("dit_password", store.get("dit", "dit"));
-    assertEquals("dot_password", store.get("dot", "dot"));
-    assertEquals("dat_password", store.get("dat", "dat"));
-    assertEquals("", store.get("done", "done"));
-    assertEquals(null, store.get(null, null));
+    assertEquals("dit_password", store.get(null, "dit", "dit"));
+    assertEquals("dot_password", store.get(null, "dot", "dot"));
+    assertEquals("dat_password", store.get(null, "dat", "dat"));
+    assertEquals("", store.get(null, "done", "done"));
+    assertEquals(null, store.get(null, null, null));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/security/VaultStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/VaultStoreTest.java
@@ -40,12 +40,14 @@ public class VaultStoreTest {
   @Test
   public void testGet() throws Exception {
     String password = "Pa$$w0rd";
+    String tenant = "diku";
+    String clientId = "abcdef1234";
 
     LogicalResponse successResp = new LogicalResponse(
         new RestResponse(
             200,
             APPLICATION_JSON,
-            ("{\"data\":{\"diku\":\"" + password + "\"}}").getBytes()),
+            String.format("{\"data\":{\"%s\":\"%s\"}}", tenant, password).getBytes()),
         0);
 
     LogicalResponse failureResp = new LogicalResponse(
@@ -57,11 +59,11 @@ public class VaultStoreTest {
 
     Logical logical = mock(Logical.class);
     when(vault.logical()).thenReturn(logical);
-    when(logical.read("secret/diku")).thenReturn(successResp);
-    when(logical.read("secret/bogus")).thenReturn(failureResp);
+    when(logical.read(clientId + "/" + tenant)).thenReturn(successResp);
+    when(logical.read(clientId + "/bogus")).thenReturn(failureResp);
 
-    assertEquals(password, secureStore.get("diku", "diku"));
-    assertNull(secureStore.get("bogus", "bogus"));
+    assertEquals(password, secureStore.get(clientId, "diku", "diku"));
+    assertNull(secureStore.get(clientId, "bogus", "bogus"));
   }
 
   // TODO Add test coverage for SSL/TLS configuration


### PR DESCRIPTION
The API Keys we're currently using are easy to guess.  They consist of a URL safe base64 encoding of the tenant ID.  So if you know the tenantId, you can easily generate the API Key.

There are a couple things we can do to improve this, that don't require much effort:

- Incorporate a username into the apiKey.  This could be the same as the tenantId or something different
- Incorporate some sort of clientId or salt into the apiKey.  

### For example:

`apiKey = urlBase64( clientId + delim + tenantId + delim + username )`

The key into the secure store would then incorporate those three pieces of information as well.  

The benefit of doing this is that the clientId would only be known to us, so even if someone knew the tenantId, and was able to find or guess the institutional user's username, they would still have to guess or brute force the clientID.

### Concrete example:

```
clientID/salt = gYn0uFv3Lf (random string)
tenantID = fs00000000
username = fs00000000 (same as tenantID)
delim = "_"

apiKey = urlBase64(gYn0uFv3Lf_fs00000000_fs00000000) 
apiKey = Z1luMHVGdjNMZl9mczAwMDAwMDAwX2ZzMDAwMDAwMD=A
```
