### PR TITLE
token cache key should include clientId from apiKey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>0.2.1-SNAPSHOT</version>
+  <version>0.2.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>

--- a/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
+++ b/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
@@ -49,7 +49,7 @@ public class InstitutionalUserHelper {
     String token = null;
     try {
       TokenCache cache = TokenCache.getInstance();
-      token = cache.get(tenant, username);
+      token = cache.get(clientId, tenant, username);
     } catch (NotInitializedException e) {
       logger.warn("Failed to access TokenCache", e);
     }
@@ -72,7 +72,7 @@ public class InstitutionalUserHelper {
       } else {
         loginFuture.thenAccept(t -> {
           try {
-            TokenCache.getInstance().put(tenant, username, t);
+            TokenCache.getInstance().put(clientId, tenant, username, t);
           } catch (NotInitializedException e) {
             logger.warn("Failed to cache token", e);
           }

--- a/src/main/java/org/folio/edge/core/cache/TokenCache.java
+++ b/src/main/java/org/folio/edge/core/cache/TokenCache.java
@@ -62,16 +62,16 @@ public class TokenCache {
     return instance;
   }
 
-  public String get(String tenant, String username) {
-    return cache.get(computeKey(tenant, username));
+  public String get(String clientId, String tenant, String username) {
+    return cache.get(computeKey(clientId, tenant, username));
   }
 
-  public CacheValue<String> put(String tenant, String username, String token) {
-    return cache.put(computeKey(tenant, username), token);
+  public CacheValue<String> put(String clientId, String tenant, String username, String token) {
+    return cache.put(computeKey(clientId, tenant, username), token);
   }
 
-  private String computeKey(String tenant, String username) {
-    return String.format("%s:%s", tenant, username);
+  private String computeKey(String clientId, String tenant, String username) {
+    return String.format("%s:%s:%s", clientId, tenant, username);
   }
 
   public static class NotInitializedException extends RuntimeException {

--- a/src/test/java/org/folio/edge/core/cache/TokenCacheTest.java
+++ b/src/test/java/org/folio/edge/core/cache/TokenCacheTest.java
@@ -21,6 +21,7 @@ public class TokenCacheTest {
 
   private final String tenant = "diku";
   private final String user = "diku";
+  private final String clientId = "abc123";
   private final String val = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkaWt1IiwidXNlcl9pZCI6Ijk3ZTNmYzVmLTVjMzMtNGY2Ny1hZmRiLWEzYjI5YTVhYWZjOCIsInRlbmFudCI6ImRpa3UifQ.uda9KgBn82jCR3FXd73CnkmfDDk3OBQI0bjrJ5L7oJ8fS_7-TDNj7UKiFl-YxnqwFGHGACprsG5Bp7kkG8ArZA";
 
   @Before
@@ -32,7 +33,7 @@ public class TokenCacheTest {
   @Test
   public void testReinitialize() throws Exception {
     logger.info("=== Test Reinitialize... ===");
-    final CacheValue<String> cached = TokenCache.getInstance().put(tenant, user, val);
+    final CacheValue<String> cached = TokenCache.getInstance().put(clientId, tenant, user, val);
 
     await().with()
       .pollInterval(20, TimeUnit.MILLISECONDS)
@@ -40,7 +41,7 @@ public class TokenCacheTest {
       .until(() -> cached.expired());
 
     TokenCache.initialize(ttl * 2, nullValueTtl, cap);
-    final CacheValue<String> cached2 = TokenCache.getInstance().put(tenant, user, val);
+    final CacheValue<String> cached2 = TokenCache.getInstance().put(clientId, tenant, user, val);
 
     await().with()
       .pollInterval(20, TimeUnit.MILLISECONDS)
@@ -54,7 +55,7 @@ public class TokenCacheTest {
     logger.info("=== Test that a new cache is empty... ===");
 
     // empty cache...
-    assertNull(TokenCache.getInstance().get(tenant, user));
+    assertNull(TokenCache.getInstance().get(clientId, tenant, user));
   }
 
   @Test
@@ -64,11 +65,11 @@ public class TokenCacheTest {
     TokenCache cache = TokenCache.getInstance();
 
     // empty cache...
-    assertNull(cache.get(tenant, user));
+    assertNull(cache.get(clientId, tenant, user));
 
     // basic functionality
-    cache.put(tenant, user, val);
-    assertEquals(val, cache.get(tenant, user));
+    cache.put(clientId, tenant, user, val);
+    assertEquals(val, cache.get(clientId, tenant, user));
   }
 
   @Test
@@ -79,19 +80,19 @@ public class TokenCacheTest {
     String baseVal = "val";
 
     // make sure we don't overwrite the cached value
-    cache.put(tenant, user, baseVal);
-    assertEquals(baseVal, cache.get(tenant, user));
+    cache.put(clientId, tenant, user, baseVal);
+    assertEquals(baseVal, cache.get(clientId, tenant, user));
 
     for (int i = 0; i < 100; i++) {
-      cache.put(tenant, user, baseVal + i);
-      assertEquals(baseVal, cache.get(tenant, user));
+      cache.put(clientId, tenant, user, baseVal + i);
+      assertEquals(baseVal, cache.get(clientId, tenant, user));
     }
 
     // should expire very soon, if not already.
     await().with()
       .pollInterval(20, TimeUnit.MILLISECONDS)
       .atMost(ttl + 100, TimeUnit.MILLISECONDS)
-      .until(() -> cache.get(tenant, user) == null);
+      .until(() -> cache.get(clientId, tenant, user) == null);
   }
 
   @Test
@@ -101,7 +102,7 @@ public class TokenCacheTest {
     TokenCache cache = TokenCache.getInstance();
     String baseVal = "val";
 
-    CacheValue<String> cached = cache.put(tenant, user + 0, baseVal);
+    CacheValue<String> cached = cache.put(clientId, tenant, user + 0, baseVal);
     await().with()
       .pollInterval(20, TimeUnit.MILLISECONDS)
       .atMost(ttl + 100, TimeUnit.MILLISECONDS)
@@ -109,15 +110,15 @@ public class TokenCacheTest {
 
     // load capacity + 1 entries triggering eviction of expired
     for (int i = 1; i <= cap; i++) {
-      cache.put(tenant, user + i, baseVal + i);
+      cache.put(clientId, tenant, user + i, baseVal + i);
     }
 
     // should be evicted as it's expired
-    assertNull(cache.get(tenant, user + 0));
+    assertNull(cache.get(clientId, tenant, user + 0));
 
     // should still be cached
     for (int i = 1; i <= cap; i++) {
-      assertEquals(baseVal + i, cache.get(tenant, user + i));
+      assertEquals(baseVal + i, cache.get(clientId, tenant, user + i));
     }
   }
 
@@ -130,15 +131,15 @@ public class TokenCacheTest {
 
     // load capacity + 1 entries triggering eviction of the first
     for (int i = 0; i <= cap; i++) {
-      cache.put(tenant, user + i, baseVal + i);
+      cache.put(clientId, tenant, user + i, baseVal + i);
     }
 
     // should be evicted as it's the oldest
-    assertNull(cache.get(tenant, user + 0));
+    assertNull(cache.get(clientId, tenant, user + 0));
 
     // should still be cached
     for (int i = 1; i <= cap; i++) {
-      assertEquals(baseVal + i, cache.get(tenant, user + i));
+      assertEquals(baseVal + i, cache.get(clientId, tenant, user + i));
     }
   }
 
@@ -148,15 +149,15 @@ public class TokenCacheTest {
 
     TokenCache cache = TokenCache.getInstance();
 
-    CacheValue<String> cached = cache.put(tenant, user, null);
+    CacheValue<String> cached = cache.put(clientId, tenant, user, null);
 
-    assertNull(cache.get(tenant, user));
+    assertNull(cache.get(clientId, tenant, user));
 
     await().with()
       .pollInterval(20, TimeUnit.MILLISECONDS)
       .atMost(nullValueTtl + 100, TimeUnit.MILLISECONDS)
       .until(() -> cached.expired());
 
-    assertNull(cache.get(tenant, user));
+    assertNull(cache.get(clientId, tenant, user));
   }
 }


### PR DESCRIPTION
The key used by the token cache should incorporate the clientId portion of the apiKey to prevent a bad apiKey from using a cached token