### PR TITLE
fast fail on missing password

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>0.2.2-SNAPSHOT</version>
+  <version>0.2.3-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>

--- a/src/main/java/org/folio/edge/core/security/AwsParamStore.java
+++ b/src/main/java/org/folio/edge/core/security/AwsParamStore.java
@@ -15,7 +15,6 @@ import com.amazonaws.internal.CredentialsEndpointProvider;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
-import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
 
 public class AwsParamStore extends SecureStore {
 
@@ -79,26 +78,17 @@ public class AwsParamStore extends SecureStore {
   }
 
   @Override
-  public String get(String clientId, String tenant, String username) {
-    String ret = null;
-
+  public String get(String clientId, String tenant, String username) throws NotFoundException {
     String key = String.format("%s_%s_%s", clientId, tenant, username);
     GetParameterRequest req = new GetParameterRequest()
       .withName(key)
       .withWithDecryption(true);
 
     try {
-      GetParameterResult res = ssm.getParameter(req);
-      if (res != null) {
-        ret = res.getParameter().getValue();
-      }
+      return ssm.getParameter(req).getParameter().getValue();
     } catch (Exception e) {
-      logger.error(String.format(
-          "Exception retreiving password for %s: ",
-          key),
-          e);
+      throw new NotFoundException(e);
     }
-    return ret;
   }
 
   protected static class ECSCredentialsEndpointProvider extends CredentialsEndpointProvider {

--- a/src/main/java/org/folio/edge/core/security/EphemeralStore.java
+++ b/src/main/java/org/folio/edge/core/security/EphemeralStore.java
@@ -39,9 +39,14 @@ public class EphemeralStore extends SecureStore {
   }
 
   @Override
-  public String get(String clientId, String tenant, String username) {
+  public String get(String clientId, String tenant, String username) throws NotFoundException {
     // NOTE: ignore clientId
-    return store.get(getKey(tenant, username));
+    String key = getKey(tenant, username);
+    String ret = store.get(key);
+    if(ret == null) {
+      throw new NotFoundException("Nothing associated w/ key: " + key);
+    }
+    return ret;
   }
 
   private void put(String tenant, String username, String value) {

--- a/src/main/java/org/folio/edge/core/security/SecureStore.java
+++ b/src/main/java/org/folio/edge/core/security/SecureStore.java
@@ -10,6 +10,20 @@ public abstract class SecureStore {
     this.properties = properties;
   }
 
-  public abstract String get(String clientId, String tenant, String username);
+  public abstract String get(String clientId, String tenant, String username) throws NotFoundException;
+
+  public static class NotFoundException extends Exception {
+
+    private static final long serialVersionUID = 1586174011075039404L;
+
+    public NotFoundException(String msg) {
+      super(msg);
+    }
+
+    public NotFoundException(Throwable t) {
+      super(t);
+    }
+
+  }
 
 }

--- a/src/main/java/org/folio/edge/core/security/VaultStore.java
+++ b/src/main/java/org/folio/edge/core/security/VaultStore.java
@@ -71,21 +71,19 @@ public class VaultStore extends SecureStore {
   }
 
   @Override
-  public String get(String clientId, String tenant, String username) {
-    String ret = null;
-
+  public String get(String clientId, String tenant, String username) throws NotFoundException {
     try {
-      ret = vault.logical()
-        .read(String.format("%s/%s", clientId, tenant))
+      String key = String.format("%s/%s", clientId, tenant);
+      String ret = vault.logical()
+        .read(key)
         .getData()
         .get(username);
+      if (ret == null) {
+        throw new NotFoundException(String.format("Attribute: %s not set for %s", username, key));
+      }
+      return ret;
     } catch (VaultException e) {
-      logger.error(String.format("Exception retreiving password for secret/%s:%s: %s",
-          tenant,
-          username,
-          e.getMessage()));
+      throw new NotFoundException(e);
     }
-
-    return ret;
   }
 }

--- a/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 import org.apache.http.HttpHeaders;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.folio.edge.core.security.SecureStore.NotFoundException;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -132,7 +133,7 @@ public class AwsParamStoreTest {
   }
 
   @Test
-  public void testGetFound() {
+  public void testGetFound() throws Exception {
     // test data & expected values
     String clientId = "ditdatdot";
     String tenant = "foo";
@@ -149,22 +150,18 @@ public class AwsParamStoreTest {
     assertEquals(val, secureStore.get(clientId, tenant, user));
   }
 
-  @Test
-  public void testGetNotFound() {
+  @Test(expected = NotFoundException.class)
+  public void testGetNotFound() throws NotFoundException {
     String exceptionMsg = "Parameter null_null not found. (Service: AWSSimpleSystemsManagement; Status Code: 400; Error Code: ParameterNotFound; Request ID: 25fc4a22-9839-4645-b7b4-ad40aa643821)";
-    String logMsg = "Exception retreiving password for null_null_null: ";
     Throwable exception = new AWSSimpleSystemsManagementException(exceptionMsg);
 
     when(ssm.getParameter(any())).thenThrow(exception);
 
-    TestUtils.assertLogMessage(AwsParamStore.logger, 1, 1, Level.ERROR, logMsg, exception, () -> {
-      String val = secureStore.get(null, null, null);
-      assertNull(val);
-    });
+    secureStore.get(null, null, null);
   }
 
   @Test
-  public void testUseEcsCredentialProvider() {
+  public void testUseEcsCredentialProvider() throws Exception {
     Properties properties = new Properties();
     properties.setProperty(AwsParamStore.PROP_USE_IAM, "false");
     properties.setProperty(AwsParamStore.PROP_ECS_CREDENTIALS_ENDPOINT, ecsCredEndpoint);

--- a/src/test/java/org/folio/edge/core/security/EphemeralStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/EphemeralStoreTest.java
@@ -2,10 +2,12 @@ package org.folio.edge.core.security;
 
 import static org.folio.edge.core.utils.test.TestUtils.assertLogMessage;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Properties;
 
 import org.apache.log4j.Level;
+import org.folio.edge.core.security.SecureStore.NotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,13 +41,19 @@ public class EphemeralStoreTest {
   }
 
   @Test
-  public void testGet() {
+  public void testGet() throws Exception {
     assertEquals(4, store.store.size());
     assertEquals("dit_password", store.get(null, "dit", "dit"));
     assertEquals("dot_password", store.get(null, "dot", "dot"));
     assertEquals("dat_password", store.get(null, "dat", "dat"));
     assertEquals("", store.get(null, "done", "done"));
-    assertEquals(null, store.get(null, null, null));
+
+    try {
+      store.get(null, null, null);
+      fail("Expected " + NotFoundException.class.getName());
+    } catch (NotFoundException e) {
+
+    }
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/security/VaultStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/VaultStoreTest.java
@@ -2,12 +2,13 @@ package org.folio.edge.core.security;
 
 import static org.folio.edge.core.Constants.APPLICATION_JSON;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
+import org.folio.edge.core.security.SecureStore.NotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -37,7 +38,7 @@ public class VaultStoreTest {
     MockitoAnnotations.initMocks(this);
   }
 
-  @Test
+  @Test(expected = NotFoundException.class)
   public void testGet() throws Exception {
     String password = "Pa$$w0rd";
     String tenant = "diku";
@@ -63,7 +64,7 @@ public class VaultStoreTest {
     when(logical.read(clientId + "/bogus")).thenReturn(failureResp);
 
     assertEquals(password, secureStore.get(clientId, "diku", "diku"));
-    assertNull(secureStore.get(clientId, "bogus", "bogus"));
+    secureStore.get(clientId, "bogus", "bogus");
   }
 
   // TODO Add test coverage for SSL/TLS configuration


### PR DESCRIPTION
The original implementation would log an error and continue w/ an empty string for the password when one could not be obtained from the secure store.  This essentially pushed the responsibility of failing the request out to FOLIO.

Given that this will almost never work (empty passwords shouldn't be allowed anyway), we should just fail the request right then and there, before even making a request to FOLIO.