### PR TITLE
Base Handler for code shared among all edge API requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>0.2.4-SNAPSHOT</version>
+  <version>0.2.5-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>

--- a/src/main/java/org/folio/edge/core/Constants.java
+++ b/src/main/java/org/folio/edge/core/Constants.java
@@ -42,6 +42,12 @@ public class Constants {
   // Param names
   public static final String PARAM_API_KEY = "apikey";
 
+  // Response messages
+  public static final String MSG_ACCESS_DENIED = "Access Denied";
+  public static final String MSG_INTERNAL_SERVER_ERROR = "Internal Server Error";
+  public static final String MSG_REQUEST_TIMEOUT = "Request to FOLIO timed out";
+  public static final String MSG_NOT_IMPLEMENTED = "Not Implemented";
+
   // Misc
   public static final long DAY_IN_MILLIS = 24 * 60 * 60 * 1000L;
 }

--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -21,8 +21,8 @@ public abstract class Handler {
 
   private static final Logger logger = Logger.getLogger(Handler.class);
 
-  private InstitutionalUserHelper iuHelper;
-  private OkapiClientFactory ocf;
+  protected InstitutionalUserHelper iuHelper;
+  protected OkapiClientFactory ocf;
 
   public Handler(SecureStore secureStore, OkapiClientFactory ocf) {
     this.ocf = ocf;

--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -1,0 +1,133 @@
+package org.folio.edge.core;
+
+import static org.folio.edge.core.Constants.PARAM_API_KEY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.log4j.Logger;
+import org.folio.edge.core.InstitutionalUserHelper.MalformedApiKeyException;
+import org.folio.edge.core.model.ClientInfo;
+import org.folio.edge.core.security.SecureStore;
+import org.folio.edge.core.utils.OkapiClient;
+import org.folio.edge.core.utils.OkapiClientFactory;
+
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+
+public abstract class Handler {
+
+  private static final Logger logger = Logger.getLogger(Handler.class);
+
+  private InstitutionalUserHelper iuHelper;
+  private OkapiClientFactory ocf;
+
+  public Handler(SecureStore secureStore, OkapiClientFactory ocf) {
+    this.ocf = ocf;
+    this.iuHelper = new InstitutionalUserHelper(secureStore);
+  }
+
+  protected void handleCommon(RoutingContext ctx, String[] requiredParams, String[] optionalParams,
+      TwoParamVoidFunction<OkapiClient, Map<String, String>> action) {
+    String key = ctx.request().getParam(PARAM_API_KEY);
+    if (key == null || key.isEmpty()) {
+      accessDenied(ctx, "Missing required parameter: " + PARAM_API_KEY);
+      return;
+    }
+
+    Map<String, String> params = new HashMap<>(requiredParams.length);
+    for (String param : requiredParams) {
+      String value = ctx.request().getParam(param);
+      if (value == null || value.isEmpty()) {
+        badRequest(ctx, "Missing required parameter: " + param);
+        return;
+      } else {
+        params.put(param, value);
+      }
+    }
+
+    for (String param : optionalParams) {
+      params.put(param, ctx.request().getParam(param));
+    }
+
+    ClientInfo clientInfo;
+    try {
+      clientInfo = InstitutionalUserHelper.parseApiKey(key);
+    } catch (MalformedApiKeyException e) {
+      accessDenied(ctx, e.getMessage());
+      return;
+    }
+
+    final OkapiClient client = ocf.getOkapiClient(clientInfo.tenantId);
+
+    iuHelper.getToken(client,
+        clientInfo.clientId,
+        clientInfo.tenantId,
+        clientInfo.username)
+      .thenAcceptAsync(token -> {
+        client.setToken(token);
+        action.apply(client, params);
+      })
+      .exceptionally(t -> {
+        if (t instanceof TimeoutException) {
+          requestTimeout(ctx, t.getMessage());
+        } else {
+          accessDenied(ctx, t.getMessage());
+        }
+        return null;
+      });
+  }
+
+  protected void handleProxyResponse(RoutingContext ctx, HttpClientResponse resp) {
+    final StringBuilder body = new StringBuilder();
+    resp.handler(buf -> {
+
+      if (logger.isTraceEnabled()) {
+        logger.trace("read bytes: " + buf.toString());
+      }
+
+      body.append(buf);
+    }).endHandler(v -> {
+      ctx.response().setStatusCode(resp.statusCode());
+
+      String respBody = body.toString();
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("response: " + respBody);
+      }
+
+      String contentType = resp.getHeader(HttpHeaders.CONTENT_TYPE);
+      if (contentType != null) {
+        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType);
+      }
+
+      ctx.response().end(respBody);
+    });
+  }
+
+  protected void handleProxyException(RoutingContext ctx, Throwable t) {
+    logger.error("Exception calling OKAPI", t);
+    if (t instanceof TimeoutException) {
+      requestTimeout(ctx, t.getMessage());
+    } else {
+      internalServerError(ctx, t.getMessage());
+    }
+  }
+
+  protected abstract void accessDenied(RoutingContext ctx, String body);
+
+  protected abstract void badRequest(RoutingContext ctx, String body);
+
+  protected abstract void notFound(RoutingContext ctx, String body);
+
+  protected abstract void requestTimeout(RoutingContext ctx, String body);
+
+  protected abstract void internalServerError(RoutingContext ctx, String body);
+
+  @FunctionalInterface
+  public interface TwoParamVoidFunction<A, B> {
+    public void apply(A a, B b);
+  }
+}

--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -1,6 +1,7 @@
 package org.folio.edge.core;
 
 import static org.folio.edge.core.Constants.PARAM_API_KEY;
+import static org.folio.edge.core.Constants.TEXT_PLAIN;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,7 +18,7 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.ext.web.RoutingContext;
 
-public abstract class Handler {
+public class Handler {
 
   private static final Logger logger = Logger.getLogger(Handler.class);
 
@@ -116,15 +117,42 @@ public abstract class Handler {
     }
   }
 
-  protected abstract void accessDenied(RoutingContext ctx, String body);
+  protected void accessDenied(RoutingContext ctx, String msg) {
+    ctx.response()
+      .setStatusCode(403)
+      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+      .end(msg);
+  }
 
-  protected abstract void badRequest(RoutingContext ctx, String body);
+  protected void badRequest(RoutingContext ctx, String msg) {
+    ctx.response()
+      .setStatusCode(400)
+      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+      .end(msg);
+  }
 
-  protected abstract void notFound(RoutingContext ctx, String body);
+  protected void notFound(RoutingContext ctx, String msg) {
+    ctx.response()
+      .setStatusCode(404)
+      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+      .end(msg);
+  }
 
-  protected abstract void requestTimeout(RoutingContext ctx, String body);
+  protected void requestTimeout(RoutingContext ctx, String msg) {
+    ctx.response()
+      .setStatusCode(408)
+      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+      .end(msg);
+  }
 
-  protected abstract void internalServerError(RoutingContext ctx, String body);
+  protected void internalServerError(RoutingContext ctx, String msg) {
+    if (!ctx.response().ended()) {
+      ctx.response()
+        .setStatusCode(500)
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end(msg);
+    }
+  }
 
   @FunctionalInterface
   public interface TwoParamVoidFunction<A, B> {

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -31,6 +31,14 @@ public class OkapiClient {
 
   protected final MultiMap defaultHeaders = MultiMap.caseInsensitiveMultiMap();
 
+  public OkapiClient(OkapiClient client) {
+    this.reqTimeout = client.reqTimeout;
+    this.tenant = client.tenant;
+    this.okapiURL = client.okapiURL;
+    this.client = client.client;
+    this.setToken(client.getToken());
+  }
+
   protected OkapiClient(Vertx vertx, String okapiURL, String tenant, long timeout) {
     this.reqTimeout = timeout;
     this.okapiURL = okapiURL;

--- a/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
@@ -253,46 +253,6 @@ public class EdgeVerticleTest {
         .setStatusCode(200)
         .end("Success");
     }
-
-    @Override
-    protected void accessDenied(RoutingContext ctx, String msg) {
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .setStatusCode(403)
-        .end(msg);
-    }
-
-    @Override
-    protected void badRequest(RoutingContext ctx, String msg) {
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .setStatusCode(400)
-        .end(msg);
-    }
-
-    @Override
-    protected void notFound(RoutingContext ctx, String msg) {
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .setStatusCode(404)
-        .end(msg);
-    }
-
-    @Override
-    protected void requestTimeout(RoutingContext ctx, String msg) {
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .setStatusCode(408)
-        .end(msg);
-    }
-
-    @Override
-    protected void internalServerError(RoutingContext ctx, String msg) {
-      ctx.response()
-        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .setStatusCode(500)
-        .end(msg);
-    }
   }
 
 }


### PR DESCRIPTION
Develop a base Handler class that removes the need to deal with common/boilerplate code for:

* Verifying that required parameters are present 
* Obtaining required and optional parameters from the request
* Obtaining an OKAPI Token (via the TokenCache or logging in)

Convenience methods for proxying the response from FOLIO back to the original caller (in both success and failure scenarios) are provided.

Generic methods for various error responses are defined as well, and can be overridden to suite your specific needs.