### PR TITLE
Created EdgeVerticle2 that supports DeploymentOptions for config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,2 +1,9 @@
+10/30/2018
+ - Added an edge verticle implementation that allows deployment options to be
+   set by the verticle launcher. This required moving much of the code from
+   the constructor into the `start` method. This allows the launcher to provide
+   a vertx to the verticle which contains the deployment options. It also allows
+   the verticle to perform time consuming tasks without blocking the main
+   thread.
 08/16/2018
  - The source of the API Key is now configurable via the `api_key_sources` system property.  See [README.md](README.md) for details.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>0.3.6-SNAPSHOT</version>
+  <version>0.3.7-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>

--- a/src/main/java/org/folio/edge/core/Constants.java
+++ b/src/main/java/org/folio/edge/core/Constants.java
@@ -1,5 +1,11 @@
 package org.folio.edge.core;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.core.json.JsonObject;
+
 public class Constants {
 
   private Constants() {
@@ -58,4 +64,34 @@ public class Constants {
 
   // Misc
   public static final long DAY_IN_MILLIS = 24 * 60 * 60 * 1000L;
+
+  // Seed the default deployment options with the system env variables or
+  // the defaults defined above.
+  public static final JsonObject DEFAULT_DEPLOYMENT_OPTIONS;
+  static {
+    final Map<String, Object> defaultMap = new HashMap<>();
+
+    defaultMap.put(SYS_PORT,
+        Integer.parseInt(System.getProperty(SYS_PORT, DEFAULT_PORT)));
+    defaultMap.put(SYS_LOG_LEVEL,
+        System.getProperty(SYS_LOG_LEVEL, DEFAULT_LOG_LEVEL));
+    defaultMap.put(SYS_API_KEY_SOURCES,
+        System.getProperty(SYS_API_KEY_SOURCES, DEFAULT_API_KEY_SOURCES));
+    defaultMap.put(SYS_REQUEST_TIMEOUT_MS,
+        Long.parseLong(System.getProperty(SYS_REQUEST_TIMEOUT_MS,
+            Long.toString(DEFAULT_REQUEST_TIMEOUT_MS))));
+    defaultMap.put(SYS_TOKEN_CACHE_TTL_MS,
+        Long.parseLong(System.getProperty(SYS_TOKEN_CACHE_TTL_MS,
+            Long.toString(DEFAULT_TOKEN_CACHE_TTL_MS))));
+    defaultMap.put(SYS_NULL_TOKEN_CACHE_TTL_MS,
+        Long.parseLong(System.getProperty(SYS_NULL_TOKEN_CACHE_TTL_MS,
+            Long.toString(DEFAULT_NULL_TOKEN_CACHE_TTL_MS))));
+    defaultMap.put(SYS_TOKEN_CACHE_CAPACITY,
+        Integer.parseInt(System.getProperty(SYS_TOKEN_CACHE_CAPACITY,
+            Integer.toString(DEFAULT_TOKEN_CACHE_CAPACITY))));
+    defaultMap.put(SYS_SECURE_STORE_TYPE,
+        System.getProperty(SYS_SECURE_STORE_TYPE, DEFAULT_SECURE_STORE_TYPE));
+
+    DEFAULT_DEPLOYMENT_OPTIONS = new JsonObject(Collections.unmodifiableMap(defaultMap));
+  }
 }

--- a/src/main/java/org/folio/edge/core/EdgeVerticle2.java
+++ b/src/main/java/org/folio/edge/core/EdgeVerticle2.java
@@ -1,0 +1,126 @@
+package org.folio.edge.core;
+
+import static org.folio.edge.core.Constants.DEFAULT_SECURE_STORE_TYPE;
+import static org.folio.edge.core.Constants.PROP_SECURE_STORE_TYPE;
+import static org.folio.edge.core.Constants.SYS_API_KEY_SOURCES;
+import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
+import static org.folio.edge.core.Constants.SYS_NULL_TOKEN_CACHE_TTL_MS;
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_PORT;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
+import static org.folio.edge.core.Constants.SYS_SECURE_STORE_TYPE;
+import static org.folio.edge.core.Constants.SYS_TOKEN_CACHE_CAPACITY;
+import static org.folio.edge.core.Constants.SYS_TOKEN_CACHE_TTL_MS;
+import static org.folio.edge.core.Constants.TEXT_PLAIN;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.folio.edge.core.cache.TokenCache;
+import org.folio.edge.core.security.SecureStore;
+import org.folio.edge.core.security.SecureStoreFactory;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+
+public abstract class EdgeVerticle2 extends AbstractVerticle {
+
+  private static final Logger logger = Logger.getLogger(EdgeVerticle2.class);
+
+  private static Pattern isURL = Pattern.compile("(?i)^http[s]?://.*");
+
+  protected SecureStore secureStore;
+
+  @Override
+  public void start(Future<Void> future) {
+    JsonObject jo = Constants.DEFAULT_DEPLOYMENT_OPTIONS.copy();
+    config().mergeIn(jo.mergeIn(config()));
+
+    final int port = config().getInteger(SYS_PORT);
+    logger.info("Using port: " + port);
+
+    final String logLvl = config().getString(SYS_LOG_LEVEL);
+    Logger.getRootLogger().setLevel(Level.toLevel(logLvl));
+    logger.info("Using log level: " + logLvl);
+
+    logger.info("Using okapi URL: " + config().getString(SYS_OKAPI_URL));
+    logger.info("Using API key sources: " + config().getString(SYS_API_KEY_SOURCES));
+
+    final long cacheTtlMs = config().getLong(SYS_TOKEN_CACHE_TTL_MS);
+    logger.info("Using token cache TTL (ms): " + cacheTtlMs);
+
+    final long failureCacheTtlMs = config().getLong(SYS_NULL_TOKEN_CACHE_TTL_MS);
+    logger.info("Using token cache TTL (ms): " + failureCacheTtlMs);
+
+    final int cacheCapacity = config().getInteger(SYS_TOKEN_CACHE_CAPACITY);
+    logger.info("Using token cache capacity: " + cacheCapacity);
+
+    logger.info("Using request timeout (ms): " + config().getLong(SYS_REQUEST_TIMEOUT_MS));
+
+    // initialize the TokenCache
+    TokenCache.initialize(cacheTtlMs, failureCacheTtlMs, cacheCapacity);
+
+    secureStore = initializeSecureStore(config().getString(SYS_SECURE_STORE_PROP_FILE));
+
+    final HttpServer server = getVertx().createHttpServer();
+
+    final Router router = defineRoutes();
+
+    server.requestHandler(router::accept).listen(port, result -> {
+      if (result.succeeded()) {
+        future.complete();
+      } else {
+        future.fail(result.cause());
+      }
+    });
+  }
+
+  public abstract Router defineRoutes();
+
+  protected SecureStore initializeSecureStore(String secureStorePropFile) {
+    Properties secureStoreProps = new Properties();
+
+    if (secureStorePropFile != null) {
+      URL url = null;
+      try {
+        if (isURL.matcher(secureStorePropFile).matches()) {
+          url = new URL(secureStorePropFile);
+        }
+
+        try (InputStream in = url == null ? new FileInputStream(secureStorePropFile) : url.openStream()) {
+          secureStoreProps.load(in);
+          logger.info("Successfully loaded properties from: " +
+              secureStorePropFile);
+        }
+      } catch (Exception e) {
+        logger.warn("Failed to load secure store properties.", e);
+      }
+    } else {
+      logger.warn("No secure store properties file specified.  Using defaults");
+    }
+
+    // Order of precedence: system property, properties file, default
+    String type = config().getString(SYS_SECURE_STORE_TYPE,
+        secureStoreProps.getProperty(PROP_SECURE_STORE_TYPE, DEFAULT_SECURE_STORE_TYPE));
+
+    return SecureStoreFactory.getSecureStore(type, secureStoreProps);
+  }
+
+  protected void handleHealthCheck(RoutingContext ctx) {
+    ctx.response()
+      .setStatusCode(200)
+      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+      .end("\"OK\"");
+  }
+}

--- a/src/test/java/org/folio/edge/core/ConstantsTest.java
+++ b/src/test/java/org/folio/edge/core/ConstantsTest.java
@@ -1,41 +1,10 @@
 package org.folio.edge.core;
 
-import static org.junit.Assert.*;
-
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ConstantsTest {
-  @BeforeClass
-  public static void setUpOnce() throws Exception {
-    System.setProperty("port", "2112");
-  }
-
   @Test(expected = UnsupportedOperationException.class)
   public final void testUnmodifiableDepoymentOptions() {
     Constants.DEFAULT_DEPLOYMENT_OPTIONS.put("test", "invalid");
-  }
-
-  @Test
-  public final void testDepolymentOptionsWithEnvVars() {
-    assertEquals(Integer.valueOf(2112), Constants.DEFAULT_DEPLOYMENT_OPTIONS.getInteger(Constants.SYS_PORT));
-  }
-
-  @Test
-  public final void testDepolymentOptionsWithDefaults() {
-    assertEquals(Constants.DEFAULT_LOG_LEVEL,
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getString(Constants.SYS_LOG_LEVEL));
-    assertEquals(Constants.DEFAULT_API_KEY_SOURCES,
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getString(Constants.SYS_API_KEY_SOURCES));
-    assertEquals(Long.valueOf(Constants.DEFAULT_REQUEST_TIMEOUT_MS),
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getLong(Constants.SYS_REQUEST_TIMEOUT_MS));
-    assertEquals(Long.valueOf(Constants.DEFAULT_TOKEN_CACHE_TTL_MS),
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getLong(Constants.SYS_TOKEN_CACHE_TTL_MS));
-    assertEquals(Long.valueOf(Constants.DEFAULT_NULL_TOKEN_CACHE_TTL_MS),
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getLong(Constants.SYS_NULL_TOKEN_CACHE_TTL_MS));
-    assertEquals(Integer.valueOf(Constants.DEFAULT_TOKEN_CACHE_CAPACITY),
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getInteger(Constants.SYS_TOKEN_CACHE_CAPACITY));
-    assertEquals(Constants.DEFAULT_SECURE_STORE_TYPE,
-        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getString(Constants.SYS_SECURE_STORE_TYPE));
   }
 }

--- a/src/test/java/org/folio/edge/core/ConstantsTest.java
+++ b/src/test/java/org/folio/edge/core/ConstantsTest.java
@@ -1,0 +1,41 @@
+package org.folio.edge.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ConstantsTest {
+  @BeforeClass
+  public static void setUpOnce() throws Exception {
+    System.setProperty("port", "2112");
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public final void testUnmodifiableDepoymentOptions() {
+    Constants.DEFAULT_DEPLOYMENT_OPTIONS.put("test", "invalid");
+  }
+
+  @Test
+  public final void testDepolymentOptionsWithEnvVars() {
+    assertEquals(Integer.valueOf(2112), Constants.DEFAULT_DEPLOYMENT_OPTIONS.getInteger(Constants.SYS_PORT));
+  }
+
+  @Test
+  public final void testDepolymentOptionsWithDefaults() {
+    assertEquals(Constants.DEFAULT_LOG_LEVEL,
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getString(Constants.SYS_LOG_LEVEL));
+    assertEquals(Constants.DEFAULT_API_KEY_SOURCES,
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getString(Constants.SYS_API_KEY_SOURCES));
+    assertEquals(Long.valueOf(Constants.DEFAULT_REQUEST_TIMEOUT_MS),
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getLong(Constants.SYS_REQUEST_TIMEOUT_MS));
+    assertEquals(Long.valueOf(Constants.DEFAULT_TOKEN_CACHE_TTL_MS),
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getLong(Constants.SYS_TOKEN_CACHE_TTL_MS));
+    assertEquals(Long.valueOf(Constants.DEFAULT_NULL_TOKEN_CACHE_TTL_MS),
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getLong(Constants.SYS_NULL_TOKEN_CACHE_TTL_MS));
+    assertEquals(Integer.valueOf(Constants.DEFAULT_TOKEN_CACHE_CAPACITY),
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getInteger(Constants.SYS_TOKEN_CACHE_CAPACITY));
+    assertEquals(Constants.DEFAULT_SECURE_STORE_TYPE,
+        Constants.DEFAULT_DEPLOYMENT_OPTIONS.getString(Constants.SYS_SECURE_STORE_TYPE));
+  }
+}

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -1,0 +1,344 @@
+package org.folio.edge.core;
+
+import static org.folio.edge.core.Constants.MSG_ACCESS_DENIED;
+import static org.folio.edge.core.Constants.MSG_REQUEST_TIMEOUT;
+import static org.folio.edge.core.Constants.PARAM_API_KEY;
+import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_PORT;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
+import static org.folio.edge.core.Constants.TEXT_PLAIN;
+import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
+import static org.folio.edge.core.utils.test.MockOkapi.X_ECHO_STATUS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.log4j.Logger;
+import org.folio.edge.core.model.ClientInfo;
+import org.folio.edge.core.security.SecureStore;
+import org.folio.edge.core.security.SecureStore.NotFoundException;
+import org.folio.edge.core.utils.ApiKeyUtils;
+import org.folio.edge.core.utils.ApiKeyUtils.MalformedApiKeyException;
+import org.folio.edge.core.utils.OkapiClient;
+import org.folio.edge.core.utils.OkapiClientFactory;
+import org.folio.edge.core.utils.test.MockOkapi;
+import org.folio.edge.core.utils.test.TestUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.response.Response;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+
+@RunWith(VertxUnitRunner.class)
+public class EdgeVerticle2Test {
+
+  private static final Logger logger = Logger.getLogger(EdgeVerticle2Test.class);
+
+  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
+  private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
+  private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
+  private static final long requestTimeoutMs = 10000L;
+
+  private static Vertx vertx;
+  private static MockOkapi mockOkapi;
+
+  @BeforeClass
+  public static void setUpOnce(TestContext context) throws Exception {
+    int okapiPort = TestUtils.getPort();
+    int serverPort = TestUtils.getPort();
+
+    List<String> knownTenants = new ArrayList<>();
+    knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
+
+    mockOkapi = spy(new MockOkapi(okapiPort, knownTenants));
+    mockOkapi.start(context);
+
+    vertx = Vertx.vertx();
+
+    JsonObject jo = new JsonObject()
+        .put(SYS_PORT, serverPort)
+        .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
+        .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
+        .put(SYS_LOG_LEVEL, "TRACE")
+        .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs);
+
+    final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
+    vertx.deployVerticle(TestVerticle.class.getName(), opt, context.asyncAssertSuccess());
+
+    RestAssured.baseURI = "http://localhost:" + serverPort;
+    RestAssured.port = serverPort;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
+
+  @AfterClass
+  public static void tearDownOnce(TestContext context) {
+    logger.info("Shutting down server");
+    vertx.close(res -> {
+      if (res.failed()) {
+        logger.error("Failed to shut down edge-rtac server", res.cause());
+        fail(res.cause().getMessage());
+      } else {
+        logger.info("Successfully shut down edge-rtac server");
+      }
+
+      logger.info("Shutting down mock Okapi");
+      mockOkapi.close();
+    });
+  }
+
+  @Test
+  public void testAdminHealth(TestContext context) {
+    logger.info("=== Test the health check endpoint ===");
+
+    final Response resp = RestAssured
+      .get("/admin/health")
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(200)
+      .extract()
+      .response();
+
+    assertEquals("\"OK\"", resp.body().asString());
+  }
+
+  @Test
+  public void testLoginUnknownApiKey(TestContext context) throws Exception {
+    logger.info("=== Test request with unknown apiKey (tenant) ===");
+
+    RestAssured
+      .get(String.format("/login/and/do/something?apikey=%s&foo=bar", unknownTenantApiKey))
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(403);
+  }
+
+  @Test
+  public void testLoginMissingApiKey(TestContext context) throws Exception {
+    logger.info("=== Test request without specifying an apiKey ===");
+
+    RestAssured
+      .get("/login/and/do/something?apikey=&foo=bar")
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(401);
+  }
+
+  @Test
+  public void testLoginBadApiKey(TestContext context) throws Exception {
+    logger.info("=== Test request with malformed apiKey ===");
+
+    RestAssured
+      .get(String.format("/login/and/do/something?apikey=%s&foo=bar", badApiKey))
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(401);
+  }
+
+  @Test
+  public void testExceptionHandler(TestContext context) throws Exception {
+    logger.info("=== Test the exception handler ===");
+
+    RestAssured
+      .get("/internal/server/error")
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(500);
+  }
+
+  @Test
+  public void testMissingRequired(TestContext context) throws Exception {
+    logger.info("=== Test request w/ missing required parameter ===");
+
+    final Response resp = RestAssured
+      .with()
+      .header(HttpHeaders.CONTENT_TYPE.toString(), TEXT_PLAIN)
+      .body("success")
+      .get(String.format("/login/and/do/something?apikey=%s", apiKey))
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(400)
+      .extract()
+      .response();
+
+    assertEquals("Missing required parameter: foo", resp.body().asString());
+  }
+
+  @Test
+  public void test404(TestContext context) throws Exception {
+    logger.info("=== Test 404 rseponse ===");
+
+    final Response resp = RestAssured
+      .with()
+      .header(HttpHeaders.CONTENT_TYPE.toString(), TEXT_PLAIN)
+      .header(X_ECHO_STATUS, "404")
+      .body("Not Found")
+      .get(String.format("/login/and/do/something?apikey=%s&foo=bar", apiKey))
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(404)
+      .extract()
+      .response();
+
+    assertEquals("Not Found", resp.body().asString());
+  }
+
+  @Test
+  public void testCachedToken(TestContext context) throws Exception {
+    logger.info("=== Test the tokens are cached and reused ===");
+
+    int iters = 5;
+
+    for (int i = 0; i < iters; i++) {
+      final Response resp = RestAssured
+        .with()
+        .header(HttpHeaders.CONTENT_TYPE.toString(), TEXT_PLAIN)
+        .body("success")
+        .get(String.format("/login/and/do/something?apikey=%s&foo=bar", apiKey))
+        .then()
+        .contentType(TEXT_PLAIN)
+        .statusCode(200)
+        .extract()
+        .response();
+
+      assertEquals("success", resp.body().asString());
+    }
+
+    verify(mockOkapi).loginHandler(any());
+  }
+
+  @Test
+  public void testRequestTimeout(TestContext context) throws Exception {
+    logger.info("=== Test request timeout ===");
+
+    final Response resp = RestAssured
+      .with()
+      .header(X_DURATION, requestTimeoutMs * 2)
+      .get(String.format("/always/login?apikey=%s", apiKey))
+      .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(408)
+      .extract()
+      .response();
+
+    assertEquals(MSG_REQUEST_TIMEOUT, resp.body().asString());
+  }
+
+  public static class TestVerticle extends EdgeVerticle2 {
+
+    @Override
+    public Router defineRoutes() {
+      OkapiClientFactory ocf = new OkapiClientFactory(vertx, config().getString(SYS_OKAPI_URL), config().getLong(SYS_REQUEST_TIMEOUT_MS));
+      InstitutionalUserHelper iuHelper = new InstitutionalUserHelper(secureStore);
+      ApiKeyHelper apiKeyHelper = new ApiKeyHelper("HEADER,PARAM,PATH");
+
+      Router router = Router.router(vertx);
+      router.route().handler(BodyHandler.create());
+      router.route(HttpMethod.GET, "/admin/health").handler(this::handleHealthCheck);
+      router.route(HttpMethod.GET, "/always/login")
+        .handler(new GetTokenHandler(iuHelper, ocf, secureStore, apiKeyHelper, false)::handle);
+      router.route(HttpMethod.GET, "/login/and/do/something")
+        .handler(new GetTokenHandler(iuHelper, ocf, secureStore, apiKeyHelper, true)::handle);
+      router.route(HttpMethod.GET, "/internal/server/error")
+        .handler(new handle500(secureStore, ocf)::handle);
+      return router;
+    }
+  }
+
+  private static class GetTokenHandler extends Handler {
+    public final boolean useCache;
+
+    public GetTokenHandler(InstitutionalUserHelper iuHelper, OkapiClientFactory ocf, SecureStore secureStore,
+        ApiKeyHelper keyHelper, boolean useCache) {
+      super(secureStore, ocf, keyHelper);
+      this.useCache = useCache;
+    }
+
+    public void handle(RoutingContext ctx) {
+      if (useCache) {
+        super.handleCommon(ctx,
+            new String[] { "foo" },
+            new String[] {},
+            (client, params) -> {
+              logger.info("Token: " + client.getToken());
+              client.post(String.format("%s/echo", client.okapiURL),
+                  client.tenant,
+                  ctx.getBodyAsString(),
+                  ctx.request().headers(),
+                  resp -> handleProxyResponse(ctx, resp),
+                  t -> handleProxyException(ctx, t));
+            });
+      } else {
+        ClientInfo clientInfo;
+        try {
+          clientInfo = ApiKeyUtils.parseApiKey(ctx.request().getParam(PARAM_API_KEY));
+        } catch (MalformedApiKeyException e) {
+          accessDenied(ctx, MSG_ACCESS_DENIED);
+          return;
+        }
+
+        String password = null;
+        try {
+          password = iuHelper.secureStore.get(clientInfo.clientId, clientInfo.tenantId, clientInfo.username);
+        } catch (NotFoundException e) {
+          accessDenied(ctx, MSG_ACCESS_DENIED);
+          return;
+        }
+
+        final OkapiClient client = ocf.getOkapiClient(clientInfo.tenantId);
+        client.login(clientInfo.username, password, ctx.request().headers())
+          .thenAcceptAsync(token -> {
+            logger.info("Token: " + token);
+            client.post(String.format("%s/echo", client.okapiURL),
+                client.tenant,
+                ctx.getBodyAsString(),
+                ctx.request().headers(),
+                resp -> handleProxyResponse(ctx, resp),
+                t -> handleProxyException(ctx, t));
+          })
+          .exceptionally(t -> {
+            if (t.getCause() instanceof TimeoutException) {
+              requestTimeout(ctx, MSG_REQUEST_TIMEOUT);
+            } else {
+              accessDenied(ctx, MSG_ACCESS_DENIED);
+            }
+            return null;
+          });
+      }
+    }
+  }
+
+  private static class handle500 extends Handler {
+
+    public handle500(SecureStore secureStore, OkapiClientFactory ocf) {
+      super(secureStore, ocf);
+    }
+
+    public void handle(RoutingContext ctx) {
+      ocf.getOkapiClient("").get("http://some.bogus.url", "",
+          resp -> handleProxyResponse(ctx, resp),
+          t -> handleProxyException(ctx, t));
+    }
+
+  }
+}

--- a/src/test/java/org/folio/edge/core/utils/MappersTest.java
+++ b/src/test/java/org/folio/edge/core/utils/MappersTest.java
@@ -35,10 +35,14 @@ public class MappersTest {
 
     StringBuilder sb = new StringBuilder();
     sb.append(Mappers.XML_PROLOG)
-      .append("<test>\n")
-      .append("  <a>").append(a).append("</a>\n")
-      .append("  <b>").append(b).append("</b>\n")
-      .append("</test>\n");
+      .append("<test>")
+      .append(System.lineSeparator())
+      .append("  <a>").append(a).append("</a>")
+      .append(System.lineSeparator())
+      .append("  <b>").append(b).append("</b>")
+      .append(System.lineSeparator())
+      .append("</test>")
+      .append(System.lineSeparator());
 
     TestObject obj = new TestObject(a, b);
 


### PR DESCRIPTION
The existing `EdgeVerticle` creates a vertx object in its constructor. This causes the `AbstractVerticle` to lose its vertx, which is supplied by the launch script. The launch vertx has the context where the deployment options are provided to the verticle, so deployment options are not available with `EdgeVerticle`.

To get around this, `EdgeVerticle2` was created. The constructor no longer creates a vertx and all operations are now done in the verticle `start` method using the launch provided vertx instance. The `start` method is provided by the `AbstractVerticle` and we use this method to perform our potentially long setup operations (secure store loading, etc.) that could block the main thread. Other entry points to the verticle behave synchronously, so are not ideal for this purpose.

Default deployment options are loaded by the verticle. These can be overridden by env variable, which can be further be overridden by deployment options provided by the launcher.