### PR TITLE
EDGCOMMON-9: EdgeVerticle2: support of HttpServer Options

### DIFF
--- a/src/main/java/org/folio/edge/core/Constants.java
+++ b/src/main/java/org/folio/edge/core/Constants.java
@@ -23,6 +23,7 @@ public class Constants {
   public static final String SYS_LOG_LEVEL = "log_level";
   public static final String SYS_REQUEST_TIMEOUT_MS = "request_timeout_ms";
   public static final String SYS_API_KEY_SOURCES = "api_key_sources";
+  public static final String SYS_RESPONSE_COMPRESSION = "response_compression";
 
   // Property names
   public static final String PROP_SECURE_STORE_TYPE = "secureStore.type";

--- a/src/main/java/org/folio/edge/core/Constants.java
+++ b/src/main/java/org/folio/edge/core/Constants.java
@@ -37,6 +37,7 @@ public class Constants {
   public static final long DEFAULT_NULL_TOKEN_CACHE_TTL_MS = 30 * 1000L;
   public static final int DEFAULT_TOKEN_CACHE_CAPACITY = 100;
   public static final String DEFAULT_API_KEY_SOURCES = "PARAM,HEADER,PATH";
+  public static final boolean DEFAULT_RESPONSE_COMPRESSION = false;
 
   // Headers
   public static final String X_OKAPI_TENANT = "x-okapi-tenant";
@@ -92,6 +93,9 @@ public class Constants {
             Integer.toString(DEFAULT_TOKEN_CACHE_CAPACITY))));
     defaultMap.put(SYS_SECURE_STORE_TYPE,
         System.getProperty(SYS_SECURE_STORE_TYPE, DEFAULT_SECURE_STORE_TYPE));
+    defaultMap.put(SYS_RESPONSE_COMPRESSION,
+        Boolean.parseBoolean(System.getProperty(SYS_RESPONSE_COMPRESSION,
+            Boolean.toString(DEFAULT_RESPONSE_COMPRESSION))));
 
     DEFAULT_DEPLOYMENT_OPTIONS = new JsonObject(Collections.unmodifiableMap(defaultMap));
   }

--- a/src/main/java/org/folio/edge/core/EdgeVerticle2.java
+++ b/src/main/java/org/folio/edge/core/EdgeVerticle2.java
@@ -8,6 +8,7 @@ import static org.folio.edge.core.Constants.SYS_NULL_TOKEN_CACHE_TTL_MS;
 import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
 import static org.folio.edge.core.Constants.SYS_PORT;
 import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
 import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
 import static org.folio.edge.core.Constants.SYS_SECURE_STORE_TYPE;
 import static org.folio.edge.core.Constants.SYS_TOKEN_CACHE_CAPACITY;
@@ -20,6 +21,7 @@ import java.net.URL;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import io.vertx.core.http.HttpServerOptions;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.cache.TokenCache;
@@ -73,7 +75,15 @@ public abstract class EdgeVerticle2 extends AbstractVerticle {
 
     secureStore = initializeSecureStore(config().getString(SYS_SECURE_STORE_PROP_FILE));
 
-    final HttpServer server = getVertx().createHttpServer();
+    // enable response compression if property 'response_compression' = true,
+    // disable compression if 'response_compression' = false or not exists at all
+    final HttpServerOptions serverOptions = new HttpServerOptions();
+    if (config().containsKey(SYS_RESPONSE_COMPRESSION)) {
+      serverOptions.setCompressionSupported(config().getBoolean(SYS_RESPONSE_COMPRESSION));
+    }
+    logger.info("Response compression enabled: " + serverOptions.isCompressionSupported());
+
+    final HttpServer server = getVertx().createHttpServer(serverOptions);
 
     final Router router = defineRoutes();
 

--- a/src/main/java/org/folio/edge/core/EdgeVerticle2.java
+++ b/src/main/java/org/folio/edge/core/EdgeVerticle2.java
@@ -75,13 +75,11 @@ public abstract class EdgeVerticle2 extends AbstractVerticle {
 
     secureStore = initializeSecureStore(config().getString(SYS_SECURE_STORE_PROP_FILE));
 
-    // enable response compression if property 'response_compression' = true,
-    // disable compression if 'response_compression' = false or not exists at all
+    // initialize response compression
+    final boolean isCompressionSupported = config().getBoolean(SYS_RESPONSE_COMPRESSION);
+    logger.info("Response compression enabled: " + isCompressionSupported);
     final HttpServerOptions serverOptions = new HttpServerOptions();
-    if (config().containsKey(SYS_RESPONSE_COMPRESSION)) {
-      serverOptions.setCompressionSupported(config().getBoolean(SYS_RESPONSE_COMPRESSION));
-    }
-    logger.info("Response compression enabled: " + serverOptions.isCompressionSupported());
+    serverOptions.setCompressionSupported(isCompressionSupported);
 
     final HttpServer server = getVertx().createHttpServer(serverOptions);
 

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -7,6 +7,7 @@ import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
 import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
 import static org.folio.edge.core.Constants.SYS_PORT;
 import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
 import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
@@ -81,7 +82,8 @@ public class EdgeVerticle2Test {
         .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
         .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
         .put(SYS_LOG_LEVEL, "TRACE")
-        .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs);
+        .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
+        .put(SYS_RESPONSE_COMPRESSION, true);
 
     final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
     vertx.deployVerticle(TestVerticle.class.getName(), opt, context.asyncAssertSuccess());

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -7,7 +7,6 @@ import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
 import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
 import static org.folio.edge.core.Constants.SYS_PORT;
 import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
-import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
 import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
@@ -82,8 +81,7 @@ public class EdgeVerticle2Test {
         .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
         .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
         .put(SYS_LOG_LEVEL, "TRACE")
-        .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
-        .put(SYS_RESPONSE_COMPRESSION, true);
+        .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs);
 
     final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
     vertx.deployVerticle(TestVerticle.class.getName(), opt, context.asyncAssertSuccess());

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -131,7 +131,6 @@ public class ResponseCompressionTest {
 
         final Response resp = RestAssured.given()
                 .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
-                .header(new Header(org.apache.http.HttpHeaders.ACCEPT_ENCODING, "instance"))
                 .get("/admin/health")
                 .then()
                 .contentType(TEXT_PLAIN)

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -1,0 +1,143 @@
+package org.folio.edge.core;
+
+import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.config.DecoderConfig;
+import com.jayway.restassured.response.Header;
+import com.jayway.restassured.response.Response;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.log4j.Logger;
+import org.folio.edge.core.utils.ApiKeyUtils;
+import org.folio.edge.core.utils.test.MockOkapi;
+import org.folio.edge.core.utils.test.TestUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jayway.restassured.config.DecoderConfig.decoderConfig;
+import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_PORT;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
+import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
+import static org.folio.edge.core.Constants.TEXT_PLAIN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+
+@RunWith(VertxUnitRunner.class)
+public class ResponseCompressionTest {
+
+    private static final Logger logger = Logger.getLogger(EdgeVerticle2Test.class);
+
+    private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
+    private static final long requestTimeoutMs = 10000L;
+
+    private static Vertx vertx;
+    private static MockOkapi mockOkapi;
+
+    @BeforeClass
+    public static void setUpOnce(TestContext context) throws Exception {
+        int okapiPort = TestUtils.getPort();
+        int serverPort = TestUtils.getPort();
+
+        List<String> knownTenants = new ArrayList<>();
+        knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
+
+        mockOkapi = spy(new MockOkapi(okapiPort, knownTenants));
+        mockOkapi.start(context);
+
+        vertx = Vertx.vertx();
+
+        JsonObject jo = new JsonObject()
+                .put(SYS_PORT, serverPort)
+                .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
+                .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
+                .put(SYS_LOG_LEVEL, "TRACE")
+                .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
+                .put(SYS_RESPONSE_COMPRESSION, true);
+
+        final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
+        vertx.deployVerticle(EdgeVerticle2Test.TestVerticle.class.getName(), opt, context.asyncAssertSuccess());
+
+        RestAssured.baseURI = "http://localhost:" + serverPort;
+        RestAssured.port = serverPort;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    }
+
+    @AfterClass
+    public static void tearDownOnce(TestContext context) {
+        logger.info("Shutting down server");
+        vertx.close(res -> {
+            if (res.failed()) {
+                logger.error("Failed to shut down edge-rtac server", res.cause());
+                fail(res.cause().getMessage());
+            } else {
+                logger.info("Successfully shut down edge-rtac server");
+            }
+
+            logger.info("Shutting down mock Okapi");
+            mockOkapi.close();
+        });
+    }
+
+
+    @Test
+    public void testResponseCompression(TestContext context) {
+        logger.info("=== Test response compression (Accept-Encoding: gzip / Accept-Encoding: deflate)  ===");
+
+        for (DecoderConfig.ContentDecoder type : DecoderConfig.ContentDecoder.values()) {
+            final Response resp = RestAssured.given()
+                    .config(RestAssured.config().decoderConfig(decoderConfig().contentDecoders(type)))
+                    .get("/admin/health")
+                    .then()
+                    .contentType(TEXT_PLAIN)
+                    .statusCode(200)
+                    .header(HttpHeaders.CONTENT_ENCODING.toString(), type.name().toLowerCase())
+                    .extract()
+                    .response();
+            assertEquals("\"OK\"", resp.body().asString());
+        }
+    }
+
+    @Test
+    public void testResponseNoCompressionHeaderInstance(TestContext context) {
+        logger.info("=== Test no compression (Accept-Encoding: instance) ===");
+
+        final Response resp = RestAssured.given()
+                .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
+                .header(new Header(org.apache.http.HttpHeaders.ACCEPT_ENCODING, "instance"))
+                .get("/admin/health")
+                .then()
+                .contentType(TEXT_PLAIN)
+                .statusCode(200)
+                .extract()
+                .response();
+        assertEquals("\"OK\"", resp.body().asString());
+    }
+
+    @Test
+    public void testResponseNoCompressionWithoutAcceptEncoding(TestContext context) {
+        logger.info("=== Test no compression (without Accept-Encoding header) ===");
+
+        final Response resp = RestAssured.given()
+                .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
+                .header(new Header(org.apache.http.HttpHeaders.ACCEPT_ENCODING, "instance"))
+                .get("/admin/health")
+                .then()
+                .contentType(TEXT_PLAIN)
+                .statusCode(200)
+                .extract()
+                .response();
+        assertEquals("\"OK\"", resp.body().asString());
+    }
+}


### PR DESCRIPTION
JIRA: EDGCOMMON-9 - "EdgeVerticle2: support of HttpServer Options"
- Support of HttpServer Options in the EdgeVerticle2 enabled
- Property "response_compression" introduced