### PR TITLE
Fixes for several problems

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+## 1.0.1 Unreleased
+ * [EDGCOMMON-4](https://issues.folio.org/browse/EDGCOMMON-4): Locked in the
+   vertx version using dependency management
+ * [EDGCOMMON-7](https://issues.folio.org/browse/EDGCOMMON-7): Changed the
+   dependency to use the core args4j instead of the maven plugin
+ * [EDGCOMMON-11](https://issues.folio.org/browse/EDGCOMMON-11): A shaded fat
+   jar is no longer produced by the build
+ * [EDGCOMMON-12](https://issues.folio.org/browse/EDGCOMMON-12): Tests now wait
+   for related server shutdown completion before moving to another test
+ * [EDGCOMMON-13](https://issues.folio.org/browse/EDGCOMMON-13): Test set the
+   region for the mocked AWS param store service to avoid a potential missing
+   region exception
+
 ## 1.0.0
  * First formal release of all functionality implemented up to this point.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@
    dependency to use the core args4j instead of the maven plugin
  * [EDGCOMMON-11](https://issues.folio.org/browse/EDGCOMMON-11): A shaded fat
    jar is no longer produced by the build
+   * However, we do still need a jar with the `args4j` dependency and the
+     `ApiKeyUtils` class and related classes so we can generate API keys from
+     the command line. We now generate an executable jar file that can be used
+     to generate/parse API keys.
  * [EDGCOMMON-12](https://issues.folio.org/browse/EDGCOMMON-12): Tests now wait
    for related server shutdown completion before moving to another test
  * [EDGCOMMON-13](https://issues.folio.org/browse/EDGCOMMON-13): Test set the

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ A utility class has been provided to help with API key generate, parsing, etc.  
 ```
 $ mvn package
 
-$ java -cp target/edge-common-fat.jar org.folio.edge.core.utils.ApiKeyUtils
+$ java -jar target/edge-common-api-key-utils.jar
 Usage: ApiKeyUtils [options]
  -g                   : generate an API Key (default: false)
  -p VAL               : parse an API Key
@@ -67,10 +67,10 @@ Usage: ApiKeyUtils [options]
  -t (--tenant-id) VAL : the tenant's ID
  -u (--username) VAL  : the tenant's institutional user's username
 
-$ java -cp target/edge-common-fat.jar org.folio.edge.core.utils.ApiKeyUtils -g -s 20 -t diku -u diku
+$ java -jar target/edge-common-api-key-utils.jar -g -s 20 -t diku -u diku
 QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1
 
-$ java -cp target/edge-common-fat.jar org.folio.edge.core.utils.ApiKeyUtils -p QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1
+$ java -jar target/edge-common-api-key-utils.jar -p QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1
 Salt: BPaofNFncK6477DubxDh
 Tenant ID: diku
 Username: diku

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <dependencies>
@@ -53,27 +54,22 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.5.4</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web</artifactId>
-      <version>3.5.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
-      <version>2.9.4</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -83,7 +79,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
@@ -91,8 +86,8 @@
       <version>3.0.0</version>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke.args4j</groupId>
-      <artifactId>args4j-maven-plugin</artifactId>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
       <version>2.33</version>
     </dependency>
     <dependency>
@@ -190,29 +185,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
-    <!-- You only need the part below if you want to build your application 
-      into a fat executable jar. This is a jar that contains all the dependencies 
-      required to run it, so you can just run it with java -jar -->
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet />
-              <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 
   <repositories>
@@ -240,4 +212,22 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.5.4</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <type>pom</type>
+        <scope>import</scope>
+        <version>2.9.6</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -146,45 +146,68 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <!-- We specify the Maven compiler plugin as we need to set it to 
-          Java 1.8 -->
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
-          </configuration>
-        </plugin>
+    <plugins>
+      <!-- We specify the Maven compiler plugin as we need to set it to 
+        Java 1.8 -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
-          <configuration>
-            <preparationGoals>clean verify</preparationGoals>
-            <tagNameFormat>v@{project.version}</tagNameFormat>
-            <pushChanges>false</pushChanges>
-            <localCheckout>true</localCheckout>
-          </configuration>
-        </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.3</version>
+        <configuration>
+          <preparationGoals>clean verify</preparationGoals>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <pushChanges>false</pushChanges>
+          <localCheckout>true</localCheckout>
+        </configuration>
+      </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-          <configuration>
-            <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
-                 https://issues.folio.org/browse/FOLIO-1609
-                 https://issues.apache.org/jira/browse/SUREFIRE-1588
-            -->
-            <useSystemClassLoader>false</useSystemClassLoader>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
+               https://issues.folio.org/browse/FOLIO-1609
+               https://issues.apache.org/jira/browse/SUREFIRE-1588
+          -->
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <attach>false</attach>
+              <descriptors>
+                <descriptor>src/assembly/assembly.xml</descriptor>
+              </descriptors>
+              <archive>
+                <manifest>
+                  <mainClass>org.folio.edge.core.utils.ApiKeyUtils</mainClass>
+                </manifest>
+              </archive>
+              <artifactSet />
+              <finalName>${project.artifactId}</finalName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <repositories>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -1,0 +1,34 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+  <id>api-key-utils</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${basedir}/target/classes</directory>
+      <outputDirectory/>
+      <includes>
+        <include>org/folio/edge/core/utils/ApiKeyUtils*.class</include>
+        <include>org/folio/edge/core/model/ClientInfo*.class</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory/>
+      <useProjectArtifact>false</useProjectArtifact>
+      <unpack>true</unpack>
+      <includes>
+        <include>args4j:args4j</include>
+      </includes>
+      <unpackOptions>
+        <excludes>
+          <exclude>%regex[(?!org\/).*]</exclude>
+        </excludes>
+      </unpackOptions>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -53,7 +53,8 @@ public class MockOkapi {
     this.knownTenants = knownTenants == null ? new ArrayList<>() : knownTenants;
   }
 
-  public void close() {
+  public void close(TestContext context) {
+    final Async async = context.async();
     vertx.close(res -> {
       if (res.failed()) {
         logger.error("Failed to shut down mock OKAPI server", res.cause());
@@ -61,6 +62,7 @@ public class MockOkapi {
       } else {
         logger.info("Successfully shut down mock OKAPI server");
       }
+      async.complete();
     });
   }
 

--- a/src/test/java/org/folio/edge/core/ApiKeyHelperTest.java
+++ b/src/test/java/org/folio/edge/core/ApiKeyHelperTest.java
@@ -49,8 +49,8 @@ public class ApiKeyHelperTest {
   }
 
   @AfterClass
-  public static void tearDownOnce() throws Exception {
-    verticle.close();
+  public static void tearDownOnce(TestContext context) throws Exception {
+    verticle.close(context);
   }
 
   @Test
@@ -184,7 +184,8 @@ public class ApiKeyHelperTest {
       this.keyHelper = keyHelper;
     }
 
-    public void close() {
+    public void close(TestContext context) {
+      final Async async = context.async();
       vertx.close(res -> {
         if (res.failed()) {
           logger.error("Failed to shut down mock OKAPI server", res.cause());
@@ -192,6 +193,7 @@ public class ApiKeyHelperTest {
         } else {
           logger.info("Successfully shut down mock OKAPI server");
         }
+        async.complete();
       });
     }
 

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -44,6 +44,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
@@ -94,16 +95,18 @@ public class EdgeVerticle2Test {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     logger.info("Shutting down server");
+    final Async async = context.async();
     vertx.close(res -> {
       if (res.failed()) {
-        logger.error("Failed to shut down edge-rtac server", res.cause());
+        logger.error("Failed to shut down edge-common server", res.cause());
         fail(res.cause().getMessage());
       } else {
-        logger.info("Successfully shut down edge-rtac server");
+        logger.info("Successfully shut down edge-common server");
       }
 
       logger.info("Shutting down mock Okapi");
-      mockOkapi.close();
+      mockOkapi.close(context);
+      async.complete();
     });
   }
 
@@ -335,7 +338,7 @@ public class EdgeVerticle2Test {
     }
 
     public void handle(RoutingContext ctx) {
-      ocf.getOkapiClient("").get("http://some.bogus.url", "",
+      ocf.getOkapiClient("").get("http://url.invalid.", "",
           resp -> handleProxyResponse(ctx, resp),
           t -> handleProxyException(ctx, t));
     }

--- a/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
@@ -43,6 +43,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
@@ -57,7 +58,7 @@ public class EdgeVerticleTest {
   private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
   private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
   private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
-  private static final long requestTimeoutMs = 3000L;
+  private static final long requestTimeoutMs = 10000L;
 
   private static Vertx vertx;
   private static MockOkapi mockOkapi;
@@ -92,16 +93,18 @@ public class EdgeVerticleTest {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     logger.info("Shutting down server");
+    final Async async = context.async();
     vertx.close(res -> {
       if (res.failed()) {
-        logger.error("Failed to shut down edge-rtac server", res.cause());
+        logger.error("Failed to shut down edge-common server", res.cause());
         fail(res.cause().getMessage());
       } else {
-        logger.info("Successfully shut down edge-rtac server");
+        logger.info("Successfully shut down edge-common server");
       }
 
       logger.info("Shutting down mock Okapi");
-      mockOkapi.close();
+      mockOkapi.close(context);
+      async.complete();
     });
   }
 
@@ -333,7 +336,7 @@ public class EdgeVerticleTest {
     }
 
     public void handle(RoutingContext ctx) {
-      ocf.getOkapiClient("").get("http://some.bogus.url", "",
+      ocf.getOkapiClient("").get("http://url.invalid.", "",
           resp -> handleProxyResponse(ctx, resp),
           t -> handleProxyException(ctx, t));
     }

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -8,6 +8,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.log4j.Logger;
@@ -76,17 +77,19 @@ public class ResponseCompressionTest {
 
     @AfterClass
     public static void tearDownOnce(TestContext context) {
+        final Async async = context.async();
         logger.info("Shutting down server");
         vertx.close(res -> {
             if (res.failed()) {
-                logger.error("Failed to shut down edge-rtac server", res.cause());
+                logger.error("Failed to shut down edge-common server", res.cause());
                 fail(res.cause().getMessage());
             } else {
-                logger.info("Successfully shut down edge-rtac server");
+                logger.info("Successfully shut down edge-common server");
             }
 
             logger.info("Shutting down mock Okapi");
-            mockOkapi.close();
+            mockOkapi.close(context);
+            async.complete();
         });
     }
 

--- a/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
@@ -70,7 +70,9 @@ public class AwsParamStoreTest {
   public void setUp() throws Exception {
     // Use empty properties since the only thing configurable
     // is related to AWS, which is mocked here
-    secureStore = new AwsParamStore(new Properties());
+    Properties props = new Properties();
+    props.put(AwsParamStore.PROP_REGION, "us-east-1");
+    secureStore = new AwsParamStore(props);
 
     MockitoAnnotations.initMocks(this);
   }
@@ -101,7 +103,8 @@ public class AwsParamStoreTest {
   }
 
   @AfterClass
-  public static void tearDownOnce() throws Exception {
+  public static void tearDownOnce(TestContext context) throws Exception {
+    final Async async = context.async();
     server.close(res -> {
       if (res.failed()) {
         logger.error("Failed to shut down credentials server", res.cause());
@@ -109,6 +112,7 @@ public class AwsParamStoreTest {
       } else {
         logger.info("Successfully shut down credentials server");
       }
+      async.complete();
     });
   }
 
@@ -164,6 +168,7 @@ public class AwsParamStoreTest {
     properties.setProperty(AwsParamStore.PROP_USE_IAM, "false");
     properties.setProperty(AwsParamStore.PROP_ECS_CREDENTIALS_ENDPOINT, ecsCredEndpoint);
     properties.setProperty(AwsParamStore.PROP_ECS_CREDENTIALS_PATH, ecsCredPath);
+    properties.setProperty(AwsParamStore.PROP_REGION, "us-east-1");
 
     System.clearProperty(ACCESS_KEY_SYSTEM_PROPERTY);
     System.clearProperty(SECRET_KEY_SYSTEM_PROPERTY);

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -60,7 +60,7 @@ public class OkapiClientTest {
   @After
   public void tearDown(TestContext context) {
     client.close();
-    mockOkapi.close();
+    mockOkapi.close(context);
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
@@ -59,7 +59,7 @@ public class MockOkapiTest {
 
   @AfterClass
   public static void tearDown(TestContext context) {
-    mockOkapi.close();
+    mockOkapi.close(context);
   }
 
   @Test

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# variables are substituted from filters-[production|development].properties
+log4j.rootLogger=INFO, CONSOLE
+#log4j.rootLogger=DEBUG, CONSOLE
+
+# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n


### PR DESCRIPTION
* EDGCOMMON-4: used dependency management in maven to lock all vertx dependencies to the same (latest) version
* EDGCOMMON-7: used a more general args4j dependency, instead of the maven-plugin dependency
* EDGCOMMON-11: no longer generate a fat jar since edge-common does not provide a main class to run
* EDGCOMMON-12: ensure tests that start servers wait for them to shutdown before moving on to another test
* EDGCOMMON-13: ensure an AWS region is set in the test since there can be cases where the AWS Java SDK cannot determine a default region, which causes an exception
* fixed an encoding warning in the build by setting the source encoding to UTF-8
* increased the timeout on tests to 10,000 milliseconds since there appears to be a long delay in DNS lookup that can be greater than 3 seconds (the old value) causing 500 tests to receive a 408 (might be a Windows thing)
* changed the dummy URL to use the "invalid" top level domain as defined by some RFC. Also ended the hostname in a '.' so that the DNS resolver will treat invalid as a top level domain and not append local DNS domains (like ".internal" in AWS). This saves several lookups as the DNS resolver rattles through local domain names (there can be quite a few).