### PR TITLE
Fix for EDGCOMMON-17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,30 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <assemblyRegex>%regex[(?!org\/).*]</assemblyRegex>
+      </properties>
+    </profile>
+    <profile>
+      <id>unix</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <properties>
+        <assemblyRegex>%regex[(?!org/).*]</assemblyRegex>
+      </properties>
+    </profile>
+  </profiles>
   <repositories>
     <repository>
       <id>folio-nexus</id>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -26,7 +26,7 @@
       </includes>
       <unpackOptions>
         <excludes>
-          <exclude>%regex[(?!org\/).*]</exclude>
+          <exclude>${assemblyRegex}</exclude>
         </excludes>
       </unpackOptions>
     </dependencySet>


### PR DESCRIPTION
Used maven profiles to create OS dependent variables in order to store the assembly regex. This is to overcome the need to escape the '/' using a '\\' on Windows to make the assembly plugin work, however, the backslash causes nothing to be included on Unix. Now we can use both and only the right one will be active on the host os.