### PR TITLE
EDGCOMMON-18 Change how API keys are structured

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The API Keys used by the edge APIs are a URL safe base64 encoding of the three p
 1. Tenant ID - A FOLIO tenant ID, e.g. `diku`
 1. Institutional Username - The username of the institutional user for this tenant.  This could be the same as the tenant ID, or something else, e.g. `diku` or `dikurtac`, etc.
 
-These components are then concatenated with an underscore delimiter `_` before being base64 encoded, e.g. `nZ56F3LeAa_diku_diku`.
+A simple JSON object is created containing these components, which is then base64 encoded, e.g. `{"s":"nZ56F3LeAa","t":"diku","u":"diku"}`.  Note that the field names are abbreviated in the interest of keeping the API keys as short as reasonably possible.
 
-The final API Key looks something like: `blo1NkYzTGVBYV9kaWt1X2Rpa3U=`
+The final API Key looks something like: `eyJzIjoiblo1NkYzTGVBYSIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==`
 
 The purpose of the salt is to prevent API Key from being guessed, which would be easy if the tenant ID was known, especially if the Institutional Username was the same as the tenant ID.
 
@@ -70,7 +70,7 @@ Usage: ApiKeyUtils [options]
 $ java -jar target/edge-common-api-key-utils.jar -g -s 20 -t diku -u diku
 QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1
 
-$ java -jar target/edge-common-api-key-utils.jar -p QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1
+$ java -jar target/edge-common-api-key-utils.jar -p eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0=
 Salt: BPaofNFncK6477DubxDh
 Tenant ID: diku
 Username: diku
@@ -80,15 +80,15 @@ Username: diku
 
 The API Key can be specified as either:
 
-1) The `apiKey` query argument, e.g. `https://.../validate?apiKey=QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1`
-1) The `Authorization` request header (see note below), e.g. `Authorization: apikey QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1`
-1) As part of the URI path (denoted by `:apiKeyPath` when defining routes in VertX), e.g. `https://.../validate/QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1`
+1) The `apiKey` query argument, e.g. `https://.../validate?apiKey=eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0=`
+1) The `Authorization` request header (see note below), e.g. `Authorization: apikey eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0=`
+1) As part of the URI path (denoted by `:apiKeyPath` when defining routes in VertX), e.g. `https://.../validate/eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0=`
 
 This behavior is controlled by the `api_key_sources` system property.  The property takes a comma-separated list of sources; valid sources are `HEADER`, `PARAM`, and `PATH`.  The order in which the sources are specified determines the order in which that source will be checked for the existance of an API key.
 
 ***NOTE***:  There are two ways an API key may be provided by the `Authorization` header:
-1) `Authorization: apikey QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1` (the auth type 'apikey' is case insensitive)
-1) `Authorization: QlBhb2ZORm5jSzY0NzdEdWJ4RGhfZGlrdV9kaWt1`
+1) `Authorization: apikey eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0=` (the auth type 'apikey' is case insensitive)
+1) `Authorization: eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0=`
 
 ***TIP***:  You can limit the API Key sources used by only listing those you want to check.
 
@@ -98,7 +98,7 @@ The idea here is that a FOLIO user is created for each tenant for the purposes o
 
 The Edge API does not create users, or write credentials.  Those need to be provisioned manually or by some other process.  The current secure stores expect credentials to be stored in a way that adheres to naming conventions.  See the various secure store sections below for specifics.
 
-Currently the institutional username is the same as the tenantId, but this is subject to change.
+Currently, it's standard practive to make the institutional username the same as the tenantId, but this is not enforced programatically.
 
 ### Secure Stores
 

--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -72,7 +72,7 @@ public class Handler {
     final OkapiClient client = ocf.getOkapiClient(clientInfo.tenantId);
 
     iuHelper.getToken(client,
-        clientInfo.clientId,
+        clientInfo.salt,
         clientInfo.tenantId,
         clientInfo.username)
       .thenAcceptAsync(token -> {

--- a/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
+++ b/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
@@ -1,7 +1,6 @@
 package org.folio.edge.core;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Pattern;
 
 import org.apache.log4j.Logger;
 import org.folio.edge.core.cache.TokenCache;
@@ -17,8 +16,6 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class InstitutionalUserHelper {
   private static final Logger logger = Logger.getLogger(InstitutionalUserHelper.class);
-
-  public static final Pattern DELIM = Pattern.compile("_");
 
   protected final SecureStore secureStore;
 

--- a/src/main/java/org/folio/edge/core/model/ClientInfo.java
+++ b/src/main/java/org/folio/edge/core/model/ClientInfo.java
@@ -1,15 +1,25 @@
 package org.folio.edge.core.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ClientInfo {
 
+  @JsonProperty("t")
   public final String tenantId;
-  public final String username;
-  public final String clientId;
 
-  public ClientInfo(String clientId, String tenantId, String username) {
+  @JsonProperty("u")
+  public final String username;
+
+  @JsonProperty("s")
+  public final String salt;
+
+  @JsonCreator
+  public ClientInfo(@JsonProperty("s") String salt, @JsonProperty("t") String tenantId,
+      @JsonProperty("u") String username) {
     this.tenantId = tenantId;
     this.username = username;
-    this.clientId = clientId;
+    this.salt = salt;
   }
 
 }

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -56,9 +56,9 @@ public class EdgeVerticle2Test {
 
   private static final Logger logger = Logger.getLogger(EdgeVerticle2Test.class);
 
-  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
-  private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
-  private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
+  private static final String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "diku");
+  private static final String badApiKey = apiKey + "0000";
+  private static final String unknownTenantApiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "foobarbaz", "userA");
   private static final long requestTimeoutMs = 10000L;
 
   private static Vertx vertx;
@@ -302,7 +302,7 @@ public class EdgeVerticle2Test {
 
         String password = null;
         try {
-          password = iuHelper.secureStore.get(clientInfo.clientId, clientInfo.tenantId, clientInfo.username);
+          password = iuHelper.secureStore.get(clientInfo.salt, clientInfo.tenantId, clientInfo.username);
         } catch (NotFoundException e) {
           accessDenied(ctx, MSG_ACCESS_DENIED);
           return;

--- a/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
@@ -43,6 +43,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -55,9 +56,9 @@ public class EdgeVerticleTest {
 
   private static final Logger logger = Logger.getLogger(EdgeVerticleTest.class);
 
-  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
-  private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
-  private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
+  private static final String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "diku");
+  private static final String badApiKey = apiKey + "0000";
+  private static final String unknownTenantApiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "foobarbaz", "userA");
   private static final long requestTimeoutMs = 10000L;
 
   private static Vertx vertx;
@@ -300,7 +301,7 @@ public class EdgeVerticleTest {
 
         String password = null;
         try {
-          password = iuHelper.secureStore.get(clientInfo.clientId, clientInfo.tenantId, clientInfo.username);
+          password = iuHelper.secureStore.get(clientInfo.salt, clientInfo.tenantId, clientInfo.username);
         } catch (NotFoundException e) {
           accessDenied(ctx, MSG_ACCESS_DENIED);
           return;

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -40,7 +40,7 @@ public class ResponseCompressionTest {
 
     private static final Logger logger = Logger.getLogger(EdgeVerticle2Test.class);
 
-    private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
+    private static final String apiKey = "eyJzIjoiZ0szc0RWZ3labCIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==";
     private static final long requestTimeoutMs = 10000L;
 
     private static Vertx vertx;

--- a/src/test/java/org/folio/edge/core/utils/ApiKeyUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/ApiKeyUtilsTest.java
@@ -14,15 +14,16 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import io.vertx.core.json.JsonObject;
+
 public class ApiKeyUtilsTest {
   public static final Logger logger = Logger.getLogger(ApiKeyUtilsTest.class);
 
   public static final String SALT_LEN = "10";
   public static final String TENANT = "diku";
   public static final String USERNAME = "diku";
-  public static final String API_KEY = "Z0szc0RWZ3labF9kaWt1X2Rpa3U=";
+  public static final String API_KEY = "eyJzIjoiZ0szc0RWZ3labCIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==";
   public static final String BAD_API_KEY = "bogus";
-  public static final String DELIM = ApiKeyUtils.DELIM.pattern();
 
   public ApiKeyUtils utils;
   public ByteArrayOutputStream out;
@@ -90,24 +91,27 @@ public class ApiKeyUtilsTest {
   @Test(expected = MalformedApiKeyException.class)
   public void testParseApiKeyNullSalt() throws Exception {
     logger.info("=== Test parseApiKey - null salt ===");
+    ClientInfo ci = new ClientInfo(null, TENANT, USERNAME);
     String apiKey = Base64.getUrlEncoder()
-      .encodeToString(String.format("%s%s%s%s", DELIM, TENANT, DELIM, USERNAME).getBytes());
+      .encodeToString(JsonObject.mapFrom(ci).encode().getBytes());
     ApiKeyUtils.parseApiKey(apiKey);
   }
 
   @Test(expected = MalformedApiKeyException.class)
   public void testParseApiKeyNullTenant() throws Exception {
     logger.info("=== Test parseApiKey - null tenant ===");
+    ClientInfo ci = new ClientInfo("abcdef12345", null, USERNAME);
     String apiKey = Base64.getUrlEncoder()
-      .encodeToString(String.format("%s%s%s%s", "abcde12345", DELIM, DELIM, USERNAME).getBytes());
+      .encodeToString(JsonObject.mapFrom(ci).encode().getBytes());
     ApiKeyUtils.parseApiKey(apiKey);
   }
 
   @Test(expected = MalformedApiKeyException.class)
   public void testParseApiKeyNullUsername() throws Exception {
     logger.info("=== Test parseApiKey - null username ===");
+    ClientInfo ci = new ClientInfo("abcdef12345", TENANT, null);
     String apiKey = Base64.getUrlEncoder()
-      .encodeToString(String.format("%s%s%s%s", "abcde12345", DELIM, TENANT, DELIM).getBytes());
+      .encodeToString(JsonObject.mapFrom(ci).encode().getBytes());
     ApiKeyUtils.parseApiKey(apiKey);
   }
 
@@ -130,7 +134,7 @@ public class ApiKeyUtilsTest {
 
     ClientInfo info = ApiKeyUtils.parseApiKey(generated);
 
-    assertEquals(Integer.parseInt(SALT_LEN), info.clientId.length());
+    assertEquals(Integer.parseInt(SALT_LEN), info.salt.length());
     assertEquals(TENANT, info.tenantId);
     assertEquals(USERNAME, info.username);
   }
@@ -184,7 +188,7 @@ public class ApiKeyUtilsTest {
 
     ClientInfo info = ApiKeyUtils.parseApiKey(generated);
 
-    assertEquals(ApiKeyUtils.DEFAULT_SALT_LEN, info.clientId.length());
+    assertEquals(ApiKeyUtils.DEFAULT_SALT_LEN, info.salt.length());
     assertEquals(TENANT, info.tenantId);
     assertEquals(USERNAME, info.username);
   }


### PR DESCRIPTION
[EDGCOMMON-18](https://issues.folio.org/projects/EDGCOMMON/issues/EDGCOMMON-18)

## Purpose
The current structure of API keys is based on salt, tenantID, and username separated by an underscore (`_`) delimiter.  This is problematic since the delim character could appear in either the tenantId or username.

## Approach
Change the API key structure to use JSON, e.g.

`{"s":"ABCDEF12345","t":"diku","u":"diku_admin"}`

* ApiKeyUtils has been updated
* JSON annotations have been added to the ClientInfo class as needed for jackson mapping
* Unit tests have been updated as needed
* `clientId` has been renamed to `salt` through the code for consistency and to avoid confusion