### PR TITLE
EDGCOMMON-19 - include missing dependencies in apiKeyUtils jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
         </os>
       </activation>
       <properties>
-        <assemblyRegex>%regex[(?!org/).*]</assemblyRegex>
+        <assemblyRegex>%regex[(?!org|io|com/).*]</assemblyRegex>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         </os>
       </activation>
       <properties>
-        <assemblyRegex>%regex[(?!org|io|com\/).*]</assemblyRegex>
+        <assemblyRegex>%regex[(?!org\/|io\/|com\/).*]</assemblyRegex>
       </properties>
     </profile>
     <profile>
@@ -230,7 +230,7 @@
         </os>
       </activation>
       <properties>
-        <assemblyRegex>%regex[(?!org|io|com/).*]</assemblyRegex>
+        <assemblyRegex>%regex[(?!org/|io/|com/).*]</assemblyRegex>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         </os>
       </activation>
       <properties>
-        <assemblyRegex>%regex[(?!org\/).*]</assemblyRegex>
+        <assemblyRegex>%regex[(?!org|io|com\/).*]</assemblyRegex>
       </properties>
     </profile>
     <profile>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -19,7 +19,7 @@
   <dependencySets>
     <dependencySet>
       <outputDirectory/>
-      <useProjectArtifact>true</useProjectArtifact>
+      <useProjectArtifact>false</useProjectArtifact>
       <unpack>true</unpack>
       <includes>
         <include>args4j:args4j</include>

--- a/src/assembly/assembly.xml
+++ b/src/assembly/assembly.xml
@@ -19,10 +19,15 @@
   <dependencySets>
     <dependencySet>
       <outputDirectory/>
-      <useProjectArtifact>false</useProjectArtifact>
+      <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>
       <includes>
         <include>args4j:args4j</include>
+        <include>io.vertx:vertx-core</include>
+        <include>io.netty:netty-buffer</include>
+        <include>com.fasterxml.jackson.core:jackson-core</include>
+        <include>com.fasterxml.jackson.core:jackson-databind</include>
+        <include>com.fasterxml.jackson.core:jackson-annotations</include>
       </includes>
       <unpackOptions>
         <excludes>


### PR DESCRIPTION
## Purpose
Add missing dependencies to the API Key Utils Jar (CLI).  

[EDGCOMMON-19](https://issues.folio.org/browse/EDGCOMMON-19)

## Approach
* Add the necessary packages to the assembly inclusion list
* Update the regex exclusion pattern in pom.xml