### PR TITLE
EDGCOMMON-20: enable HTTP client compression support

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -49,7 +49,8 @@ public class OkapiClient {
     this.reqTimeout = timeout;
     this.okapiURL = okapiURL;
     this.tenant = tenant;
-    this.client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false));
+    this.client = vertx.createHttpClient(new HttpClientOptions().setKeepAlive(false)
+        .setTryUseCompression(true));
     initDefaultHeaders();
   }
 


### PR DESCRIPTION
Set the `HttpClientOption` to allow the client to request compression be used if supported by the server. This allows pass through compression headers to not cause the server to unexpectedly send compressed data to the client's handlers, since it will now be taken care of by the client prior to reaching the handler with this option set.