### PR TITLE
EDGCOMMON-25: Introduce okapi client cache to fix a memory leak.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Property                 | Default     | Description
 
 ## Additional information
 
+There will be a single instance of okapi client per OkapiClientFactory and per tenant, which means that this client should never be closed or else there will be runtime errors. To enforce this behaviour, method close() has been removed from OkapiClient class.     
+
 ### Issue tracker
 
 See project [EDGCOMMON](https://issues.folio.org/browse/EDGCOMMON)

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -255,8 +255,4 @@ public class OkapiClient {
     }
     return combined != null ? combined : defaultHeaders;
   }
-
-  public void close() {
-    client.close();
-  }
 }

--- a/src/main/java/org/folio/edge/core/utils/OkapiClientFactory.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClientFactory.java
@@ -1,8 +1,13 @@
 package org.folio.edge.core.utils;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import io.vertx.core.Vertx;
 
 public class OkapiClientFactory {
+
+  private final Map<String, OkapiClient> cache = new ConcurrentHashMap<>();
 
   public final String okapiURL;
   public final Vertx vertx;
@@ -15,6 +20,6 @@ public class OkapiClientFactory {
   }
 
   public OkapiClient getOkapiClient(String tenant) {
-    return new OkapiClient(vertx, okapiURL, tenant, reqTimeoutMs);
+    return cache.computeIfAbsent(tenant, t -> new OkapiClient(vertx, okapiURL, t, reqTimeoutMs));
   }
 }

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -59,7 +59,6 @@ public class OkapiClientTest {
 
   @After
   public void tearDown(TestContext context) {
-    client.close();
     mockOkapi.close(context);
   }
 


### PR DESCRIPTION
## Purpose

Fix a memory leak in edge-common module.

## Approach

Introduce a cache to store okapi clients.


jira: https://issues.folio.org/browse/EDGCOMMON-25
related: https://issues.folio.org/browse/EDGRTAC-33