### PR TITLE
EDGCOMMON-28: Upgrade to Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@ buildMvn {
   publishModDescriptor = 'no'
   publishAPI = 'no'
   mvnDeploy = 'yes'
+  buildNode = 'jenkins-agent-java11'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,6 @@
   </licenses>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -44,9 +42,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>2.9.0</version>
+      <version>4.3.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -148,13 +146,12 @@
   <build>
     <plugins>
       <!-- We specify the Maven compiler plugin as we need to set it to
-        Java 1.8 -->
+        Java 11 -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>${maven.compiler.source}</source>
-          <target>${maven.compiler.target}</target>
+          <release>11</release>
         </configuration>
       </plugin>
 

--- a/src/test/java/org/folio/edge/core/ApiKeyHelperTest.java
+++ b/src/test/java/org/folio/edge/core/ApiKeyHelperTest.java
@@ -15,8 +15,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -36,8 +36,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;

--- a/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
@@ -36,8 +36,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -1,9 +1,9 @@
 package org.folio.edge.core;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.config.DecoderConfig;
-import com.jayway.restassured.response.Header;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.config.DecoderConfig;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.jayway.restassured.config.DecoderConfig.decoderConfig;
+import static io.restassured.config.DecoderConfig.decoderConfig;
 import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
 import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
 import static org.folio.edge.core.Constants.SYS_PORT;

--- a/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
@@ -21,9 +21,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.config.EncoderConfig;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.response.Response;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;


### PR DESCRIPTION
Upgraded the library to build with Java 11. Rest Assured was also upgraded since the existing version uses a class that is not available in Java 11. Newer versions no longer use this class. Versions that include this fix have relocated the package, so imports needed to be updated. Actual code within tests was not impacted. No code was changed to take advantage of Java 11 features.