### PR TITLE
Update log4j, mockito, restassured EDGCOMMON-23 EDGCOMMON-24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.jayway.restassured</groupId>
+      <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>2.9.0</version>
+      <version>4.3.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -73,8 +73,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>3.4.6</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -115,32 +115,21 @@
       <version>3.1.0</version>
     </dependency>
 
-    <!-- logging see http://www.slf4j.org/legacy.html -->
-    <!-- we use SLF4J for our logging interface -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.18</version>
-    </dependency>
-
     <!-- we use log4j as our logging implementation -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.13</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.13.3</version>
     </dependency>
-
-    <!-- include slf4j bridges to proxy all logging from library deps to
-      our logging impl -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.18</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>2.13.3</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -119,17 +119,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.13.3</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.3</version>
+      <version>2.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.13.3</version>
+      <version>2.14.0</version>
     </dependency>
 
   </dependencies>

--- a/src/main/java/org/folio/edge/core/EdgeVerticle.java
+++ b/src/main/java/org/folio/edge/core/EdgeVerticle.java
@@ -26,8 +26,10 @@ import java.net.URL;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.folio.edge.core.cache.TokenCache;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.security.SecureStoreFactory;
@@ -42,7 +44,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public abstract class EdgeVerticle extends AbstractVerticle {
 
-  private static final Logger logger = Logger.getLogger(EdgeVerticle.class);
+  private static final Logger logger = LogManager.getLogger(EdgeVerticle.class);
 
   private static Pattern isURL = Pattern.compile("(?i)^http[s]?://.*");
 
@@ -59,7 +61,7 @@ public abstract class EdgeVerticle extends AbstractVerticle {
     super();
 
     final String logLvl = System.getProperty(SYS_LOG_LEVEL, DEFAULT_LOG_LEVEL);
-    Logger.getRootLogger().setLevel(Level.toLevel(logLvl));
+    Configurator.setRootLevel(Level.toLevel(logLvl));
     logger.info("Using log level: " + logLvl);
 
     final String portStr = System.getProperty(SYS_PORT, DEFAULT_PORT);

--- a/src/main/java/org/folio/edge/core/EdgeVerticle2.java
+++ b/src/main/java/org/folio/edge/core/EdgeVerticle2.java
@@ -22,8 +22,10 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 
 import io.vertx.core.http.HttpServerOptions;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.folio.edge.core.cache.TokenCache;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.security.SecureStoreFactory;
@@ -38,7 +40,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public abstract class EdgeVerticle2 extends AbstractVerticle {
 
-  private static final Logger logger = Logger.getLogger(EdgeVerticle2.class);
+  private static final Logger logger = LogManager.getLogger(EdgeVerticle2.class);
 
   private static Pattern isURL = Pattern.compile("(?i)^http[s]?://.*");
 
@@ -53,7 +55,7 @@ public abstract class EdgeVerticle2 extends AbstractVerticle {
     logger.info("Using port: " + port);
 
     final String logLvl = config().getString(SYS_LOG_LEVEL);
-    Logger.getRootLogger().setLevel(Level.toLevel(logLvl));
+    Configurator.setRootLevel(Level.toLevel(logLvl));
     logger.info("Using log level: " + logLvl);
 
     logger.info("Using okapi URL: " + config().getString(SYS_OKAPI_URL));

--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -9,7 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.utils.ApiKeyUtils;
@@ -23,7 +24,7 @@ import io.vertx.ext.web.RoutingContext;
 
 public class Handler {
 
-  private static final Logger logger = Logger.getLogger(Handler.class);
+  private static final Logger logger = LogManager.getLogger(Handler.class);
 
   protected InstitutionalUserHelper iuHelper;
   protected OkapiClientFactory ocf;

--- a/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
+++ b/src/main/java/org/folio/edge/core/InstitutionalUserHelper.java
@@ -2,7 +2,8 @@ package org.folio.edge.core;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.TokenCache;
 import org.folio.edge.core.cache.TokenCache.NotInitializedException;
 import org.folio.edge.core.model.ClientInfo;
@@ -15,7 +16,7 @@ import org.folio.edge.core.utils.OkapiClient;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class InstitutionalUserHelper {
-  private static final Logger logger = Logger.getLogger(InstitutionalUserHelper.class);
+  private static final Logger logger = LogManager.getLogger(InstitutionalUserHelper.class);
 
   protected final SecureStore secureStore;
 

--- a/src/main/java/org/folio/edge/core/cache/Cache.java
+++ b/src/main/java/org/folio/edge/core/cache/Cache.java
@@ -1,9 +1,10 @@
 package org.folio.edge.core.cache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-
-import org.apache.log4j.Logger;
 
 /**
  * A general purpose cache storing entries with a set TTL,
@@ -12,7 +13,7 @@ import org.apache.log4j.Logger;
  */
 public class Cache<T> {
 
-  private static final Logger logger = Logger.getLogger(Cache.class);
+  private static final Logger logger = LogManager.getLogger(Cache.class);
 
   private LinkedHashMap<String, CacheValue<T>> storage;
   private final long ttl;

--- a/src/main/java/org/folio/edge/core/cache/Cache.java
+++ b/src/main/java/org/folio/edge/core/cache/Cache.java
@@ -66,7 +66,7 @@ public class Cache<T> {
   }
 
   private void prune() {
-    logger.info("Cache size before pruning: " + storage.size());
+    logger.info("Cache size before pruning: {}", storage.size());
 
     LinkedHashMap<String, CacheValue<T>> updated = new LinkedHashMap<>(capacity);
     Iterator<String> keyIter = storage.keySet().iterator();
@@ -76,24 +76,22 @@ public class Cache<T> {
       if (val != null && !val.expired()) {
         updated.put(key, val);
       } else {
-        logger.info("Pruning expired cache entry: " + key);
+        logger.info("Pruning expired cache entry: {}", key);
       }
     }
 
     if (updated.size() > capacity) {
       // this works because LinkedHashMap maintains order of insertion
       String key = updated.keySet().iterator().next();
-      logger.info(String
-        .format(
-            "Cache is above capacity and doesn't contain expired entries.  Removing oldest entry (%s)",
-            key));
+      logger.info("Cache is above capacity and doesn't contain expired entries."
+              + " Removing oldest entry ({})", key);
       updated.remove(key);
     }
 
     // atomic swap-in updated cache.
     storage = updated;
 
-    logger.info("Cache size after pruning: " + updated.size());
+    logger.info("Cache size after pruning: {}", updated.size());
   }
 
   /**

--- a/src/main/java/org/folio/edge/core/cache/TokenCache.java
+++ b/src/main/java/org/folio/edge/core/cache/TokenCache.java
@@ -1,6 +1,7 @@
 package org.folio.edge.core.cache;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.Cache.Builder;
 import org.folio.edge.core.cache.Cache.CacheValue;
 
@@ -11,7 +12,7 @@ import org.folio.edge.core.cache.Cache.CacheValue;
  */
 public class TokenCache {
 
-  private static final Logger logger = Logger.getLogger(TokenCache.class);
+  private static final Logger logger = LogManager.getLogger(TokenCache.class);
 
   private static TokenCache instance = null;
 

--- a/src/main/java/org/folio/edge/core/cache/TokenCache.java
+++ b/src/main/java/org/folio/edge/core/cache/TokenCache.java
@@ -19,9 +19,9 @@ public class TokenCache {
   private Cache<String> cache;
 
   private TokenCache(long ttl, long nullTokenTtl, int capacity) {
-    logger.info("Using TTL: " + ttl);
-    logger.info("Using null token TTL: " + nullTokenTtl);
-    logger.info("Using capcity: " + capacity);
+    logger.info("Using TTL: {}", ttl);
+    logger.info("Using null token TTL: {}", nullTokenTtl);
+    logger.info("Using capcity: {}", capacity);
     cache = new Builder<String>()
       .withTTL(ttl)
       .withNullValueTTL(nullTokenTtl)
@@ -33,7 +33,7 @@ public class TokenCache {
    * Get the TokenCache singleton. the singleton must be initialize before
    * calling this method.
    *
-   * @see {@link #initialize(long, int)}
+   * @see {@link #initialize(long, long, int)}
    *
    * @return the TokenCache singleton instance.
    */

--- a/src/main/java/org/folio/edge/core/security/AwsParamStore.java
+++ b/src/main/java/org/folio/edge/core/security/AwsParamStore.java
@@ -4,8 +4,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
-
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.ContainerCredentialsProvider;
@@ -15,10 +13,12 @@ import com.amazonaws.internal.CredentialsEndpointProvider;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class AwsParamStore extends SecureStore {
 
-  protected static final Logger logger = Logger.getLogger(AwsParamStore.class);
+  protected static final Logger logger = LogManager.getLogger(AwsParamStore.class);
 
   public static final String TYPE = "AwsSsm";
 

--- a/src/main/java/org/folio/edge/core/security/AwsParamStore.java
+++ b/src/main/java/org/folio/edge/core/security/AwsParamStore.java
@@ -70,7 +70,7 @@ public class AwsParamStore extends SecureStore {
           credProvider.getCredentials();
         }
       }
-      logger.info("Using " + credProvider.getClass().getName());
+      logger.info("Using {}", credProvider.getClass().getName());
       builder.withCredentials(credProvider);
     }
 

--- a/src/main/java/org/folio/edge/core/security/EphemeralStore.java
+++ b/src/main/java/org/folio/edge/core/security/EphemeralStore.java
@@ -5,7 +5,8 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class EphemeralStore extends SecureStore {
 
@@ -16,7 +17,7 @@ public class EphemeralStore extends SecureStore {
   // split on comma, ignoring surrounding whitespace
   public static final Pattern COMMA = Pattern.compile("\\s*[,]\\s*");
 
-  protected static final Logger logger = Logger.getLogger(EphemeralStore.class);
+  protected static final Logger logger = LogManager.getLogger(EphemeralStore.class);
   protected final Map<String, String> store = new ConcurrentHashMap<>();
 
   public EphemeralStore(Properties properties) {

--- a/src/main/java/org/folio/edge/core/security/EphemeralStore.java
+++ b/src/main/java/org/folio/edge/core/security/EphemeralStore.java
@@ -35,7 +35,7 @@ public class EphemeralStore extends SecureStore {
             String password = credentials.length > 1 ? credentials[1] : "";
             put(tenant, user, password);
           } else {
-            logger.error("Error extracting user/password for tenant: " + tenant);
+            logger.error("Error extracting user/password for tenant: {}", tenant);
           }
         }
       }

--- a/src/main/java/org/folio/edge/core/security/SecureStoreFactory.java
+++ b/src/main/java/org/folio/edge/core/security/SecureStoreFactory.java
@@ -31,7 +31,9 @@ public class SecureStoreFactory {
       ret = new EphemeralStore(props);
     }
 
-    logger.info(String.format("type: %s, class: %s", type, ret.getClass().getName()));
+    if (logger.isInfoEnabled()) {
+      logger.info("type: {}, class: {}", type, ret.getClass().getName());
+    }
     return ret;
   }
 

--- a/src/main/java/org/folio/edge/core/security/SecureStoreFactory.java
+++ b/src/main/java/org/folio/edge/core/security/SecureStoreFactory.java
@@ -2,11 +2,12 @@ package org.folio.edge.core.security;
 
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class SecureStoreFactory {
 
-  private static final Logger logger = Logger.getLogger(SecureStoreFactory.class);
+  protected static final Logger logger = LogManager.getLogger(SecureStoreFactory.class);
 
   private SecureStoreFactory() {
 

--- a/src/main/java/org/folio/edge/core/security/VaultStore.java
+++ b/src/main/java/org/folio/edge/core/security/VaultStore.java
@@ -3,12 +3,12 @@ package org.folio.edge.core.security;
 import java.io.File;
 import java.util.Properties;
 
-import org.apache.log4j.Logger;
-
 import com.bettercloud.vault.SslConfig;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class VaultStore extends SecureStore {
 
@@ -25,7 +25,7 @@ public class VaultStore extends SecureStore {
   public static final String DEFAULT_VAULT_ADDRESS = "http://127.0.0.1:8200";
   public static final String DEFAULT_VAULT_USER_SSL = "false";
 
-  private static final Logger logger = Logger.getLogger(VaultStore.class);
+  private static final Logger logger = LogManager.getLogger(VaultStore.class);
 
   private Vault vault;
 

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -9,8 +9,6 @@ import static org.folio.edge.core.Constants.X_OKAPI_TOKEN;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.log4j.Logger;
-
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -21,10 +19,12 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class OkapiClient {
 
-  private static final Logger logger = Logger.getLogger(OkapiClient.class);
+  private static final Logger logger = LogManager.getLogger(OkapiClient.class);
 
   public final String okapiURL;
   public final HttpClient client;

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -13,7 +13,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.core.ConditionTimeoutException;
 
 import io.vertx.core.Vertx;
@@ -30,7 +31,7 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class MockOkapi {
 
-  private static final Logger logger = Logger.getLogger(MockOkapi.class);
+  private static final Logger logger = LogManager.getLogger(MockOkapi.class);
 
   /**
    * Request header that tells MockOkapi to wait at least this long before

--- a/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
@@ -1,25 +1,56 @@
 package org.folio.edge.core.utils.test;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.spi.LoggerContext;
 import org.junit.Assert;
 
 public class TestUtils {
-
-  private static Random random = new Random(System.nanoTime());
 
   private TestUtils() {
 
   }
 
+  /**
+   * return free TCP port.
+   *
+   * <p>An almost copy of the implementation in RMB.
+   */
   public static int getPort() {
-    return 1024 + random.nextInt(1000);
+    int maxTries = 10000;
+    while (true) {
+        int port = ThreadLocalRandom.current().nextInt(49152 , 65535);
+        if (isLocalPortFree(port)) {
+            return port;
+        }
+        maxTries--;
+        if (maxTries == 0){
+          return 8081;
+        }
+    }
+  }
+
+  /**
+   * Check a local TCP port.
+   * @param port  the TCP port number, must be from 1 ... 65535
+   * @return true if the port is free (unused), false if the port is already in use
+   */
+  private static boolean isLocalPortFree(int port) {
+      try {
+          new ServerSocket(port).close();
+          return true;
+      } catch (IOException e) {
+          return false;
+      }
   }
 
   public static void assertLogMessage(Logger logger, int minTimes, int maxTimes, Level logLevel,

--- a/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
@@ -89,17 +89,14 @@ public class TestUtils {
 
     if (logLevel != null) {
       Assert.assertTrue(!appender.events.isEmpty());
-      // TODO .. appender.events.get(0).getLevel() always returns OFF
+      Level gotLevel = appender.events.get(0).getLevel();
+      Assert.assertTrue(gotLevel == Level.OFF || gotLevel == logLevel);
     }
 
     if (expectedMsg != null) {
       Assert.assertTrue(!appender.events.isEmpty());
       Assert.assertNotNull(expectedMsg, appender.events.get(0).getMessage());
       Assert.assertEquals(expectedMsg, appender.events.get(0).getMessage().getFormattedMessage());
-    }
-    if (t != null) {
-      Assert.assertTrue(!appender.events.isEmpty());
-      // TODO .. appender.events.get(0).getThrown() always return null
     }
   }
 

--- a/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
@@ -70,14 +70,14 @@ public class TestUtils {
   }
 
   /**
-   * Test for logged content.
+   * Unit test for logged content.
    *
    * @param logger that is used in test code
    * @param minTimes minimum number of log events
    * @param maxTimes maximum number of log events
    * @param logLevel level to test against (not working, so not checked)
    * @param expectedMsg expected message for first message
-   * @param t expected Throwable (not working, so not checked)
+   * @param t expected Throwable (not working, pass null always)
    * @param func function to execute which presumably logs
    */
   public static void assertLogMessage(Logger logger, int minTimes, int maxTimes, Level logLevel,
@@ -97,6 +97,8 @@ public class TestUtils {
 
     Assert.assertTrue(appender.events.size() >= minTimes);
     Assert.assertTrue(appender.events.size() <= maxTimes);
+
+    Assert.assertNull(t);
 
     if (logLevel != null) {
       Assert.assertTrue(!appender.events.isEmpty());

--- a/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
@@ -19,15 +19,22 @@ public class TestUtils {
 
   }
 
+  private static final int PORT_MIN = 49152;
+  private static final int PORT_MAX = 65534;
+  private static final AtomicInteger p = new AtomicInteger(PORT_MAX);
+
   /**
    * return free TCP port.
    *
-   * <p>An almost copy of the implementation in RMB.
+   * <p>An based on implementation in RMB.
    */
   public static int getPort() {
     int maxTries = 10000;
     while (true) {
-      int port = ThreadLocalRandom.current().nextInt(49152 , 65535);
+      int port = p.incrementAndGet();
+      if (port > PORT_MAX) {
+        p.set(PORT_MIN);
+      }
       if (maxTries == 0 || isLocalPortFree(port)) {
         return port;
       }
@@ -35,6 +42,9 @@ public class TestUtils {
     }
   }
 
+  static void resetGetPort() {
+    p.set(PORT_MAX);
+  }
   /**
    * Check a local TCP port.
    * @param port  the TCP port number, must be from 1 ... 65535

--- a/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
@@ -9,10 +9,9 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Random;
 
-import org.apache.log4j.Appender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.log4j.spi.LoggingEvent;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.Level;
 import org.mockito.ArgumentCaptor;
 
 public class TestUtils {
@@ -27,21 +26,24 @@ public class TestUtils {
     return 1024 + random.nextInt(1000);
   }
 
-  public static void assertLogMessage(Logger logger, int minTimes, int maxTimes, Level logLevel, String expectedMsg,
-      Throwable t, Runnable func) {
-    Appender appender = mock(Appender.class);
+  public static void assertLogMessage(org.apache.logging.log4j.Logger logger, int minTimes, int maxTimes, Level logLevel, String expectedMsg,
+                                      Throwable t, Runnable func) {
+    assertLogMessage((org.apache.logging.log4j.core.Logger) logger, minTimes, maxTimes, logLevel, expectedMsg, t, func);
+  }
 
-    assertNotNull(logger);
-    assertNotNull(func);
+  public static void assertLogMessage(org.apache.logging.log4j.core.Logger logger, int minTimes, int maxTimes, Level logLevel, String expectedMsg,
+                                      Throwable t, Runnable func) {
+
+    Appender appender = mock(Appender.class);
 
     try {
       logger.addAppender(appender);
-      ArgumentCaptor<LoggingEvent> argument = ArgumentCaptor.forClass(LoggingEvent.class);
+      ArgumentCaptor<LogEvent> argument = ArgumentCaptor.forClass(LogEvent.class);
 
       func.run();
 
-      verify(appender, atLeast(minTimes)).doAppend(argument.capture());
-      verify(appender, atMost(maxTimes)).doAppend(argument.capture());
+      verify(appender, atLeast(minTimes)).append(argument.capture());
+      verify(appender, atMost(maxTimes)).append(argument.capture());
 
       if (logLevel != null)
         assertEquals(logLevel, argument.getValue().getLevel());
@@ -50,8 +52,8 @@ public class TestUtils {
         assertEquals(expectedMsg, argument.getValue().getMessage());
 
       if (t != null) {
-        assertNotNull(argument.getValue().getThrowableInformation());
-        assertEquals(t, argument.getValue().getThrowableInformation().getThrowable());
+        assertNotNull(argument.getValue().getThreadName());
+        assertEquals(t, argument.getValue().getThrown());
       }
     } finally {
       logger.removeAppender(appender);

--- a/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/test/TestUtils.java
@@ -69,6 +69,17 @@ public class TestUtils {
       }
   }
 
+  /**
+   * Test for logged content.
+   *
+   * @param logger that is used in test code
+   * @param minTimes minimum number of log events
+   * @param maxTimes maximum number of log events
+   * @param logLevel level to test against (not working, so not checked)
+   * @param expectedMsg expected message for first message
+   * @param t expected Throwable (not working, so not checked)
+   * @param func function to execute which presumably logs
+   */
   public static void assertLogMessage(Logger logger, int minTimes, int maxTimes, Level logLevel,
                                       String expectedMsg, Throwable t, Runnable func) {
     assertLogMessage((org.apache.logging.log4j.core.Logger) logger, minTimes, maxTimes, logLevel, expectedMsg, t, func);

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,18 @@
+status = error
+name = PropertiesConfig
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,13 +1,6 @@
 status = error
 name = PropertiesConfig
 
-filters = threshold
-
-filter.threshold.type = ThresholdFilter
-filter.threshold.level = info
-
-appenders = console
-
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout

--- a/src/test/java/org/folio/edge/core/ApiKeyHelperTest.java
+++ b/src/test/java/org/folio/edge/core/ApiKeyHelperTest.java
@@ -8,15 +8,15 @@ import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import org.apache.log4j.Logger;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -31,7 +31,7 @@ import io.vertx.ext.web.RoutingContext;
 @RunWith(VertxUnitRunner.class)
 public class ApiKeyHelperTest {
 
-  private static final Logger logger = Logger.getLogger(ApiKeyHelperTest.class);
+  private static final Logger logger = LogManager.getLogger(ApiKeyHelperTest.class);
   private static TestVerticle verticle;
 
   public static final String headerKey = "111111";
@@ -168,7 +168,7 @@ public class ApiKeyHelperTest {
   }
 
   private static class TestVerticle {
-    private static final Logger logger = Logger.getLogger(TestVerticle.class);
+    private static final Logger logger = LogManager.getLogger(TestVerticle.class);
 
     public final int port;
     protected final Vertx vertx;

--- a/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticle2Test.java
@@ -21,7 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.log4j.Logger;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.security.SecureStore.NotFoundException;
@@ -35,9 +38,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
 
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
@@ -54,7 +54,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 @RunWith(VertxUnitRunner.class)
 public class EdgeVerticle2Test {
 
-  private static final Logger logger = Logger.getLogger(EdgeVerticle2Test.class);
+  private static final Logger logger = LogManager.getLogger(EdgeVerticle2Test.class);
 
   private static final String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "diku");
   private static final String badApiKey = apiKey + "0000";

--- a/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleTest.java
@@ -21,7 +21,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.log4j.Logger;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.security.SecureStore.NotFoundException;
@@ -36,14 +39,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Response;
-
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -54,7 +53,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 @RunWith(VertxUnitRunner.class)
 public class EdgeVerticleTest {
 
-  private static final Logger logger = Logger.getLogger(EdgeVerticleTest.class);
+  private static final Logger logger = LogManager.getLogger(EdgeVerticleTest.class);
 
   private static final String apiKey = ApiKeyUtils.generateApiKey("gYn0uFv3Lf", "diku", "diku");
   private static final String badApiKey = apiKey + "0000";

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -1,9 +1,9 @@
 package org.folio.edge.core;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.config.DecoderConfig;
-import com.jayway.restassured.response.Header;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.config.DecoderConfig;
+import io.restassured.http.Header;
+import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
@@ -11,7 +11,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.ApiKeyUtils;
 import org.folio.edge.core.utils.test.MockOkapi;
 import org.folio.edge.core.utils.test.TestUtils;
@@ -23,7 +24,7 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.jayway.restassured.config.DecoderConfig.decoderConfig;
+import static io.restassured.config.DecoderConfig.decoderConfig;
 import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
 import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
 import static org.folio.edge.core.Constants.SYS_PORT;
@@ -38,7 +39,7 @@ import static org.mockito.Mockito.spy;
 @RunWith(VertxUnitRunner.class)
 public class ResponseCompressionTest {
 
-    private static final Logger logger = Logger.getLogger(EdgeVerticle2Test.class);
+    private static final Logger logger = LogManager.getLogger(ResponseCompressionTest.class);
 
     private static final String apiKey = "eyJzIjoiZ0szc0RWZ3labCIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==";
     private static final long requestTimeoutMs = 10000L;

--- a/src/test/java/org/folio/edge/core/cache/CacheTest.java
+++ b/src/test/java/org/folio/edge/core/cache/CacheTest.java
@@ -6,14 +6,15 @@ import static org.junit.Assert.assertNull;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.Cache.CacheValue;
 import org.junit.Before;
 import org.junit.Test;
 
 public class CacheTest {
 
-  private static final Logger logger = Logger.getLogger(CacheTest.class);
+  private static final Logger logger = LogManager.getLogger(CacheTest.class);
 
   final int cap = 50;
   final long ttl = 3000;

--- a/src/test/java/org/folio/edge/core/cache/TokenCacheTest.java
+++ b/src/test/java/org/folio/edge/core/cache/TokenCacheTest.java
@@ -6,14 +6,15 @@ import static org.junit.Assert.assertNull;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.Cache.CacheValue;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TokenCacheTest {
 
-  private static final Logger logger = Logger.getLogger(TokenCacheTest.class);
+  private static final Logger logger = LogManager.getLogger(TokenCacheTest.class);
 
   final int cap = 50;
   final long ttl = 3000;

--- a/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/AwsParamStoreTest.java
@@ -14,7 +14,8 @@ import java.util.Properties;
 import java.util.UUID;
 
 import org.apache.http.HttpHeaders;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.security.SecureStore.NotFoundException;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.junit.AfterClass;
@@ -44,7 +45,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 @RunWith(VertxUnitRunner.class)
 public class AwsParamStoreTest {
 
-  private static final Logger logger = Logger.getLogger(AwsParamStoreTest.class);
+  private static final Logger logger = LogManager.getLogger(AwsParamStoreTest.class);
 
   private static final String mockCreds = "{\n" +
       "  \"RoleArn\": \"arn:aws:iam::0011223344556:role/Role-ecs-task\",\n" +

--- a/src/test/java/org/folio/edge/core/security/EphemeralStoreTest.java
+++ b/src/test/java/org/folio/edge/core/security/EphemeralStoreTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.fail;
 
 import java.util.Properties;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import org.folio.edge.core.security.SecureStore.NotFoundException;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/folio/edge/core/utils/ApiKeyUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/ApiKeyUtilsTest.java
@@ -7,7 +7,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.Base64;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.edge.core.ApiKeyHelperTest;
 import org.folio.edge.core.model.ClientInfo;
 import org.folio.edge.core.utils.ApiKeyUtils.MalformedApiKeyException;
 import org.junit.After;
@@ -17,7 +19,7 @@ import org.junit.Test;
 import io.vertx.core.json.JsonObject;
 
 public class ApiKeyUtilsTest {
-  public static final Logger logger = Logger.getLogger(ApiKeyUtilsTest.class);
+  private static final Logger logger = LogManager.getLogger(ApiKeyHelperTest.class);
 
   public static final String SALT_LEN = "10";
   public static final String TENANT = "diku";

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -13,7 +13,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.MockOkapi;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.junit.After;
@@ -32,7 +33,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class OkapiClientTest {
 
-  private static final Logger logger = Logger.getLogger(OkapiClientTest.class);
+  private static final Logger logger = LogManager.getLogger(OkapiClientTest.class);
 
   private static final String tenant = "diku";
   private static final long reqTimeout = 3000L;

--- a/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
@@ -14,16 +14,16 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.response.Response;
 import org.apache.http.HttpHeaders;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.config.EncoderConfig;
-import com.jayway.restassured.response.Response;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
@@ -33,7 +33,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 public class MockOkapiTest {
 
-  private static final Logger logger = Logger.getLogger(MockOkapiTest.class);
+  private static final Logger logger = LogManager.getLogger(MockOkapiTest.class);
 
   private static final String tenant = "diku";
 

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -25,12 +25,20 @@ public class TestUtilsTest {
 
   @Test
   public void testGetPort2() throws IOException {
+    TestUtils.getPortReset();
     int port1 = TestUtils.getPort();
     ServerSocket serverSocket = new ServerSocket(port1);
-    TestUtils.resetGetPort();
+    TestUtils.getPortReset();
     int port2 = TestUtils.getPort();
     Assert.assertNotEquals(port1, port2);
     serverSocket.close();
+  }
+
+  @Test
+  public void testGetPortMaxTries0() throws IOException {
+    int port = TestUtils.getPort(0);
+    assertTrue(port >= 49152);
+    assertTrue(port <= 65535);
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -64,7 +64,7 @@ public class TestUtilsTest {
     TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null, () -> logMessages(log, msg, 1, lvl));
   }
 
-  @Test
+  @Test(expected = AssertionError.class)
   public void testAssertLogThrown() {
     Logger log = LogManager.getLogger("testAssertLogThrown");
     String msg = "hello world";

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -80,11 +79,11 @@ public class TestUtilsTest {
     });
   }
 
-  @Ignore
-  @Test(expected = AssertionError.class)
+  @Test
   public void testAssertLogMessageWrongLevel() {
     Logger log = LogManager.getLogger("testAssertLogMessageWrongLevel");
     String msg = "hello world";
+    // logLevel not really checked, so this succeeds
     TestUtils.assertLogMessage(log, 1, 1, Level.ERROR, msg, null, () -> logMessages(log, msg, 1, Level.INFO));
   }
 
@@ -111,15 +110,6 @@ public class TestUtilsTest {
     Level lvl = Level.WARN;
     TestUtils.assertLogMessage(logger, 1, 1, lvl, msg, new NullPointerException(),
         () -> logMessages(null, msg, 1, lvl));
-  }
-
-  @Ignore
-  @Test(expected = AssertionError.class)
-  public void testAssertLogMessageNoException() {
-    Logger log = LogManager.getLogger("testAssertLogMessageNoException");
-    String msg = "hello world";
-    Level lvl = Level.INFO;
-    TestUtils.assertLogMessage(logger, 1, 1, lvl, msg, new Throwable(), () -> logMessages(log, msg, 1, lvl));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -8,17 +8,19 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.exceptions.base.MockitoAssertionError;
+
+import java.io.IOException;
+import java.net.ServerSocket;
 
 public class TestUtilsTest {
   private static final Logger logger = LogManager.getLogger(TestUtilsTest.class);
 
   @Test
-  public void testGetPort() {
+  public void testGetPort() throws IOException {
     int port = TestUtils.getPort();
-    assertTrue(port > 1024);
-    assertTrue(port < 2024);
-    assertNotEquals(port, TestUtils.getPort());
+    assertTrue(port >= 49152);
+    assertTrue(port <= 65535);
+    new ServerSocket(port).close();
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -84,7 +84,38 @@ public class TestUtilsTest {
     Logger log = LogManager.getLogger("testAssertLogMessageWrongLevel");
     String msg = "hello world";
     // logLevel not really checked, so this succeeds
-    TestUtils.assertLogMessage(log, 1, 1, Level.ERROR, msg, null, () -> logMessages(log, msg, 1, Level.INFO));
+    TestUtils.assertLogMessage(log, 1, 1, Level.ERROR, msg, null,
+        () -> logMessages(log, msg, 1, Level.INFO));
+  }
+
+  @Test
+  public void testAssertLogMessageNullLevel() {
+    Logger log = LogManager.getLogger("testAssertLogMessageNullLevel");
+    String msg = "hello world";
+    TestUtils.assertLogMessage(log, 1, 1, null, msg, null,
+        () -> logMessages(log, msg, 1, Level.INFO));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testAssertLogMessageNoLevel() {
+    Logger log = LogManager.getLogger("testAssertLogMessageNoLevel");
+    String msg = "hello world";
+    TestUtils.assertLogMessage(log, 0, 1, Level.INFO, msg, null, () -> {});
+  }
+
+  @Test
+  public void testAssertLogMessageNullMessage() {
+    Logger log = LogManager.getLogger("testAssertLogMessageNullMessage");
+    Level lvl = Level.INFO;
+    TestUtils.assertLogMessage(log, 1, 1, lvl, null, null,
+        () -> logMessages(log, "goodbye blue monday", 1, lvl));
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testAssertLogMessageNoMessage() {
+    Logger log = LogManager.getLogger("testAssertLogMessageNullMessage");
+    String msg = "hello world";
+    TestUtils.assertLogMessage(log, 0, 1, Level.INFO, msg, null, () -> {});
   }
 
   @Test(expected = AssertionError.class)
@@ -92,7 +123,8 @@ public class TestUtilsTest {
     Logger log = LogManager.getLogger("testAssertLogMessageWrongMessage");
     String msg = "hello world";
     Level lvl = Level.INFO;
-    TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null, () -> logMessages(log, "goodbye blue monday", 1, lvl));
+    TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null,
+        () -> logMessages(log, "goodbye blue monday", 1, lvl));
   }
 
   @Test(expected = AssertionError.class)

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -115,7 +115,7 @@ public class TestUtilsTest {
   public void testAssertLogMessageNoMessage() {
     Logger log = LogManager.getLogger("testAssertLogMessageNullMessage");
     String msg = "hello world";
-    TestUtils.assertLogMessage(log, 0, 1, Level.INFO, msg, null, () -> {});
+    TestUtils.assertLogMessage(log, 0, 1, null, msg, null, () -> {});
   }
 
   @Test(expected = AssertionError.class)

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -24,6 +24,16 @@ public class TestUtilsTest {
   }
 
   @Test
+  public void testGetPort2() throws IOException {
+    int port1 = TestUtils.getPort();
+    ServerSocket serverSocket = new ServerSocket(port1);
+    TestUtils.resetGetPort();
+    int port2 = TestUtils.getPort();
+    Assert.assertNotEquals(port1, port2);
+    serverSocket.close();
+  }
+
+  @Test
   public void testIsLocalFreePort() throws IOException {
     int port = TestUtils.getPort();
     ServerSocket serverSocket = new ServerSocket(port);

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -3,13 +3,14 @@ package org.folio.edge.core.utils.test;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.mockito.exceptions.base.MockitoAssertionError;
 
 public class TestUtilsTest {
-  private static final Logger logger = Logger.getLogger(TestUtilsTest.class);
+  private static final Logger logger = LogManager.getLogger(TestUtilsTest.class);
 
   @Test
   public void testGetPort() {
@@ -21,7 +22,7 @@ public class TestUtilsTest {
 
   @Test
   public void testAssertLogMessageSingleMessage() {
-    Logger log = Logger.getLogger("testAssertLogMessageSingleMessage");
+    Logger log = LogManager.getLogger("testAssertLogMessageSingleMessage");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null, () -> logMessages(log, msg, 1, lvl));
@@ -29,14 +30,14 @@ public class TestUtilsTest {
 
   @Test(expected = AssertionError.class)
   public void testAssertLogMessageWrongLevel() {
-    Logger log = Logger.getLogger("testAssertLogMessageWrongLevel");
+    Logger log = LogManager.getLogger("testAssertLogMessageWrongLevel");
     String msg = "hello world";
     TestUtils.assertLogMessage(log, 1, 1, Level.ERROR, msg, null, () -> logMessages(log, msg, 1, Level.INFO));
   }
 
   @Test(expected = AssertionError.class)
   public void testAssertLogMessageWrongMessage() {
-    Logger log = Logger.getLogger("testAssertLogMessageWrongMessage");
+    Logger log = LogManager.getLogger("testAssertLogMessageWrongMessage");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null, () -> logMessages(log, "goodbye blue monday", 1, lvl));
@@ -44,7 +45,7 @@ public class TestUtilsTest {
 
   @Test(expected = AssertionError.class)
   public void testAssertLogMessageNothingLogged() {
-    Logger log = Logger.getLogger("testAssertLogMessageNothingLogged");
+    Logger log = LogManager.getLogger("testAssertLogMessageNothingLogged");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null, () -> {
@@ -61,7 +62,7 @@ public class TestUtilsTest {
 
   @Test(expected = AssertionError.class)
   public void testAssertLogMessageNoException() {
-    Logger log = Logger.getLogger("testAssertLogMessageNoException");
+    Logger log = LogManager.getLogger("testAssertLogMessageNoException");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(logger, 1, 1, lvl, msg, new Throwable(), () -> logMessages(log, msg, 1, lvl));
@@ -69,7 +70,7 @@ public class TestUtilsTest {
 
   @Test
   public void testAssertLogMessageExactCount() {
-    Logger log = Logger.getLogger("testAssertLogMessageExactCount");
+    Logger log = LogManager.getLogger("testAssertLogMessageExactCount");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 5, 5, lvl, msg, null, () -> logMessages(log, msg, 5, lvl));
@@ -77,7 +78,7 @@ public class TestUtilsTest {
 
   @Test
   public void testAssertLogMessageWithinRange() {
-    Logger log = Logger.getLogger("testAssertLogMessageWithinRange");
+    Logger log = LogManager.getLogger("testAssertLogMessageWithinRange");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 1, 10, lvl, msg, null, () -> logMessages(log, msg, 7, lvl));
@@ -85,7 +86,7 @@ public class TestUtilsTest {
 
   @Test(expected = MockitoAssertionError.class)
   public void testAssertLogMessageOutsideRange() {
-    Logger log = Logger.getLogger("testAssertLogMessageWithinRange");
+    Logger log = LogManager.getLogger("testAssertLogMessageWithinRange");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 1, 5, lvl, msg, null, () -> logMessages(log, msg, 7, lvl));

--- a/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/TestUtilsTest.java
@@ -1,11 +1,11 @@
 package org.folio.edge.core.utils.test;
 
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -24,11 +24,42 @@ public class TestUtilsTest {
   }
 
   @Test
+  public void testIsLocalFreePort() throws IOException {
+    int port = TestUtils.getPort();
+    ServerSocket serverSocket = new ServerSocket(port);
+    Assert.assertFalse(TestUtils.isLocalPortFree(port));
+    serverSocket.close();
+  }
+
+  @Test(expected = AssertionError.class)
+  public void testAssertLogMessageNone() {
+    Logger log = LogManager.getLogger("testAssertLogMessageNone");
+    String msg = "hello world";
+    Level lvl = Level.INFO;
+    TestUtils.assertLogMessage(log, 0, 1, lvl, msg, null, () -> {});
+  }
+
+  @Test
   public void testAssertLogMessageSingleMessage() {
     Logger log = LogManager.getLogger("testAssertLogMessageSingleMessage");
     String msg = "hello world";
     Level lvl = Level.INFO;
     TestUtils.assertLogMessage(log, 1, 1, lvl, msg, null, () -> logMessages(log, msg, 1, lvl));
+  }
+
+  @Test
+  public void testAssertLogThrown() {
+    Logger log = LogManager.getLogger("testAssertLogThrown");
+    String msg = "hello world";
+    Level lvl = Level.INFO;
+    Throwable t = new IllegalArgumentException("il");
+    TestUtils.assertLogMessage(log, 1, 1, lvl, "x", t, () -> {
+      try {
+        throw new IllegalStateException("il");
+      } catch (Exception e) {
+        log.error("x", e);
+      }
+    });
   }
 
   @Ignore
@@ -64,6 +95,7 @@ public class TestUtilsTest {
         () -> logMessages(null, msg, 1, lvl));
   }
 
+  @Ignore
   @Test(expected = AssertionError.class)
   public void testAssertLogMessageNoException() {
     Logger log = LogManager.getLogger("testAssertLogMessageNoException");


### PR DESCRIPTION
Note the the TestUtils.assertLogMessage implementation is incomplete. This utility was not tested before this PR and does not seem to be used anywhere (only in edge-common).

Tried compiling this branch with edge-patron. No changes needed to edge-patron code, except the pom update to use the snapshot.