### PR TITLE
Use request timeout EDGCOMMON-36

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -197,6 +197,8 @@ public class OkapiClient {
     logger.info("DELETE {} tenant: {} token: {}", () -> url, () -> tenant,
         () -> request.headers().get(X_OKAPI_TOKEN));
 
+    request.timeout(reqTimeout);
+
     return request.send();
   }
 

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -162,6 +162,8 @@ public class OkapiClient {
     logger.info("POST {} tenant: {} token: {}", () -> url, () -> tenant,
         () -> request.headers().get(X_OKAPI_TOKEN));
 
+    request.timeout(reqTimeout);
+
     if (payload != null) {
       logger.trace("Payload {}", () -> payload);
       return request.sendBuffer(Buffer.buffer(payload));

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -248,6 +248,8 @@ public class OkapiClient {
     logger.info("GET {} tenant: {} token: {}", () -> url, () -> tenant,
         () -> request.headers().get(X_OKAPI_TOKEN));
 
+    request.timeout(reqTimeout);
+
     return request.send();
   }
 

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -226,6 +226,8 @@ public class OkapiClient {
     logger.info("PUT {} tenant: {} token: {}", () -> url, () -> tenant,
         () ->request.headers().get(X_OKAPI_TOKEN));
 
+    request.timeout(reqTimeout);
+
     return request.send();
   }
 

--- a/src/test/java/org/folio/edge/core/EdgeVerticleHttpTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleHttpTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -240,6 +241,7 @@ public class EdgeVerticleHttpTest {
       .get(String.format("/always/login?apikey=%s", apiKey))
       .then()
       .contentType(TEXT_PLAIN)
+      .log().ifError()
       .statusCode(408)
       .extract()
       .response();
@@ -320,7 +322,7 @@ public class EdgeVerticleHttpTest {
                 t -> handleProxyException(ctx, t));
           })
           .exceptionally(t -> {
-            if (t.getCause() instanceof VertxException) {
+            if (t.getCause() instanceof TimeoutException) {
               requestTimeout(ctx, MSG_REQUEST_TIMEOUT);
             } else {
               accessDenied(ctx, MSG_ACCESS_DENIED);

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -301,4 +301,26 @@ public class OkapiClientTest {
         async.complete();
       });
   }
+
+  @Test
+  public void testTimeoutExceptionWhenResponseToPostRequestIsDelayed(TestContext context) {
+    logger.info("=== Test get w/ headers === ");
+
+    var headers = MultiMap.caseInsensitiveMultiMap();
+    // Header used to tell the mock Okapi to delay the response
+    headers.set(X_DURATION, Integer.toString(reqTimeout * 2));
+    headers.set(X_ECHO_STATUS, "200");
+    headers.set(HEADER_API_KEY, "foobarbaz");
+
+    Async async = context.async();
+    client.post(String.format("http://localhost:%s/echo", mockOkapi.okapiPort),
+      tenant,
+      "",
+      headers,
+      resp -> context.fail("shouldn't receive a response before the timeout occurs"),
+      t -> {
+        context.assertTrue(t instanceof java.util.concurrent.TimeoutException);
+        async.complete();
+      });
+  }
 }

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -283,8 +283,6 @@ public class OkapiClientTest {
 
   @Test
   public void testTimeoutExceptionWhenResponseToGetRequestIsDelayed(TestContext context) {
-    logger.info("=== Test get w/ headers === ");
-
     var headers = MultiMap.caseInsensitiveMultiMap();
     // Header used to tell the mock Okapi to delay the response
     headers.set(X_DURATION, Integer.toString(reqTimeout * 2));
@@ -293,8 +291,7 @@ public class OkapiClientTest {
 
     Async async = context.async();
     client.get(String.format("http://localhost:%s/echo", mockOkapi.okapiPort),
-      tenant,
-      headers,
+      tenant, headers,
       resp -> context.fail("shouldn't receive a response before the timeout occurs"),
       t -> {
         context.assertTrue(t instanceof java.util.concurrent.TimeoutException);
@@ -304,8 +301,6 @@ public class OkapiClientTest {
 
   @Test
   public void testTimeoutExceptionWhenResponseToPostRequestIsDelayed(TestContext context) {
-    logger.info("=== Test get w/ headers === ");
-
     var headers = MultiMap.caseInsensitiveMultiMap();
     // Header used to tell the mock Okapi to delay the response
     headers.set(X_DURATION, Integer.toString(reqTimeout * 2));
@@ -314,9 +309,25 @@ public class OkapiClientTest {
 
     Async async = context.async();
     client.post(String.format("http://localhost:%s/echo", mockOkapi.okapiPort),
-      tenant,
-      "",
-      headers,
+      tenant, "", headers,
+      resp -> context.fail("shouldn't receive a response before the timeout occurs"),
+      t -> {
+        context.assertTrue(t instanceof java.util.concurrent.TimeoutException);
+        async.complete();
+      });
+  }
+
+  @Test
+  public void testTimeoutExceptionWhenResponseToDeleteRequestIsDelayed(TestContext context) {
+    var headers = MultiMap.caseInsensitiveMultiMap();
+    // Header used to tell the mock Okapi to delay the response
+    headers.set(X_DURATION, Integer.toString(reqTimeout * 2));
+    headers.set(X_ECHO_STATUS, "200");
+    headers.set(HEADER_API_KEY, "foobarbaz");
+
+    Async async = context.async();
+    client.delete(String.format("http://localhost:%s/echo", mockOkapi.okapiPort),
+      tenant, headers,
       resp -> context.fail("shouldn't receive a response before the timeout occurs"),
       t -> {
         context.assertTrue(t instanceof java.util.concurrent.TimeoutException);

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -36,7 +36,7 @@ public class OkapiClientTest {
   private static final Logger logger = LogManager.getLogger(OkapiClientTest.class);
 
   private static final String tenant = "diku";
-  private static final int reqTimeout = 3000;
+  private static final int reqTimeout = 300;
 
   private OkapiClientFactory ocf;
   private OkapiClient client;

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -334,4 +334,22 @@ public class OkapiClientTest {
         async.complete();
       });
   }
+
+  @Test
+  public void testTimeoutExceptionWhenResponseToPutRequestIsDelayed(TestContext context) {
+    var headers = MultiMap.caseInsensitiveMultiMap();
+    // Header used to tell the mock Okapi to delay the response
+    headers.set(X_DURATION, Integer.toString(reqTimeout * 2));
+    headers.set(X_ECHO_STATUS, "200");
+    headers.set(HEADER_API_KEY, "foobarbaz");
+
+    Async async = context.async();
+    client.put(String.format("http://localhost:%s/echo", mockOkapi.okapiPort),
+      tenant, headers,
+      resp -> context.fail("shouldn't receive a response before the timeout occurs"),
+      t -> {
+        context.assertTrue(t instanceof java.util.concurrent.TimeoutException);
+        async.complete();
+      });
+  }
 }


### PR DESCRIPTION
## Context

`edge-patron` relies on the OkapiHttpClient to fail with a `TimeoutException` in order to [provide a specific response to the client](https://github.com/folio-org/edge-patron/blob/f4a471d3f5ce861aae682bb2a8973dd5166c118c/src/main/java/org/folio/edge/patron/PatronHandler.java#L72-L73).

[Upgrading edge-patron](https://github.com/folio-org/edge-patron/pull/51/files) to Vert.x 4.x also meant upgrading to a version of edge-common that also uses vert.x 4.x (version 4.1.x or greater was used for testing)

## Proposed Change

Use the request timeout configuration (as suggested in the [vert.x documentation](https://vertx.io/docs/vertx-web-client/java/)) to produce a specific TimeoutException that can be handled specifically.

## Remarks

Changed the `EdgeVerticleHttpTest` to check for the more specific TimeoutException that using the request timeout triggers as opposed to a general `VertxException` that was assumed to be caused by a timeout (that the other configuration causes)

Reduced the timeout in the `OkapiHttpClientTests` as responses from `MockOkapi` should generally be quick and for tests that rely on the timeout the test duration is relative to the timeout.

## Further Changes

At the moment, this pull request only changes `GET` and `POST` requests as those are the only ones used by `edge-patron`. If this approach is acceptable, this pull request should also include changes to `DELETE` and `PUT` requests as well.