### PR TITLE
EDGCOMMON-42: Use cryptographically strong random for token and salt

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/ApiKeyUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/ApiKeyUtils.java
@@ -1,5 +1,6 @@
 package org.folio.edge.core.utils;
 
+import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
 
@@ -13,7 +14,7 @@ import io.vertx.core.json.JsonObject;
 public class ApiKeyUtils {
 
   public static final String ALPHANUMERIC = "0123456789abcdefghijklmnopqrstuvwxyABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  public static final Random RANDOM = new Random(System.nanoTime());
+  public static final Random RANDOM = new SecureRandom();
   public static final int DEFAULT_SALT_LEN = 10;
 
   @Option(name = "-p",

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +43,7 @@ public class MockOkapi {
   public static final String X_DURATION = "X-Duration";
   public static final String X_ECHO_STATUS = "X-Echo-Status";
 
-  public static final String MOCK_TOKEN = "mynameisyonyonsonicomefromwisconsoniworkatalumbermillthereallthepeopleimeetasiwalkdownthestreetaskhowinthehelldidyougethereisaymynameisyonyonsonicomefromwisconson";
+  public static final String MOCK_TOKEN = UUID.randomUUID().toString();
 
   public final int okapiPort;
   protected final Vertx vertx;


### PR DESCRIPTION
generateSalt uses insecure new Random(System.nanoTime()).
https://cwe.mitre.org/data/definitions/330.html

MOCK_TOKEN uses a hardcoded token.
https://cwe.mitre.org/data/definitions/547.html

Switching to cryptographically strong random resolves this potential security issue.