### PR TITLE
EDGCOMMON-45: Reuse WebClient for pooling, pipe-lining, multiplexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
       <artifactId>vertx-web-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.folio.okapi</groupId>
+      <artifactId>okapi-common</artifactId>
+      <version>4.13.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -25,6 +25,7 @@ import io.vertx.core.json.JsonObject;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.WebClientFactory;
 
 public class OkapiClient {
 
@@ -53,10 +54,10 @@ public class OkapiClient {
     this.reqTimeout = timeout;
     this.okapiURL = okapiURL;
     this.tenant = tenant;
-    WebClientOptions options = new WebClientOptions().setKeepAlive(false).setTryUseCompression(true)
+    WebClientOptions options = new WebClientOptions().setTryUseCompression(true)
         .setIdleTimeoutUnit(TimeUnit.MILLISECONDS).setIdleTimeout(timeout)
         .setConnectTimeout(timeout);
-    client = WebClient.create(vertx, options);
+    client = WebClientFactory.getWebClient(vertx, options);
     initDefaultHeaders();
   }
 


### PR DESCRIPTION
Make use of HTTP/1.x pooling and keep alive, HTTP/1.1 pipe-lining, and HTTP/2 multiplexing as supported by WebClient based on HttpClient: https://vertx.io/docs/vertx-core/java/#_http1_x_pooling_and_keep_alive

For a high number of tenants (for example GBV) this will drastically reduce the number of HTTP connections and will reduce the latency resulting from establishing new connections.