### PR TITLE
EDGCOMMON-46: Vert.x 4.2.7 fixing jackson-databind DoS (CVE-2020-36518)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.4</version>
+        <version>4.2.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vertx from 4.2.4 to 4.2.7. This indirectly upgrade jackson-databind from 2.13.1 to 2.13.2.1 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2020-36518