### PR TITLE
EDGCOMMON-48: Remove vertx-completable-future for Morning Glory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,31 @@
       <artifactId>vault</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.3.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- provided dependencies needed for MockOkapi and TestUtils  -->
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!-- Runtime dependencies -->
     <dependency>
@@ -105,33 +130,9 @@
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>4.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <version>4.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
       <version>2.33</version>
-    </dependency>
-    <dependency>
-      <groupId>me.escoffier.vertx</groupId>
-      <artifactId>vertx-completable-future</artifactId>
-      <version>0.1.2</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -101,7 +101,7 @@ public class OkapiClient {
             return null;
           }
         })
-        .onFailure(cause -> logger.error("Exception during login: " + cause.getMessage(), cause));
+        .onFailure(cause -> logger.error("Exception during login: {}", cause.getMessage(), cause));
   }
 
   public CompletableFuture<Boolean> healthy() {
@@ -120,7 +120,7 @@ public class OkapiClient {
           return false;
         })
         .otherwise(t -> {
-          logger.error("Exception checking OKAPI's health: " + t.getMessage(), t);
+          logger.error("Exception checking OKAPI's health: {}", t.getMessage(), t);
           return false;
         });
   }

--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -22,7 +22,6 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.WebClientFactory;
@@ -68,65 +67,62 @@ public class OkapiClient {
   }
 
   public CompletableFuture<String> login(String username, String password) {
-    return login(username, password, null);
+    return doLogin(username, password).toCompletionStage().toCompletableFuture();
+  }
+
+  public Future<String> doLogin(String username, String password) {
+    return doLogin(username, password, null);
   }
 
   public CompletableFuture<String> login(String username, String password, MultiMap headers) {
-    VertxCompletableFuture<String> future = new VertxCompletableFuture<>(vertx);
+    return doLogin(username, password, headers).toCompletionStage().toCompletableFuture();
+  }
 
+  public Future<String> doLogin(String username, String password, MultiMap headers) {
     if (username == null || password == null) {
-      future.complete(null);
-      return future;
+      return Future.succeededFuture();
     }
 
     JsonObject payload = new JsonObject();
     payload.put("username", username);
     payload.put("password", password);
 
-    post(
-        okapiURL + "/authn/login",
-        tenant,
-        payload.encode(),
-        combineHeadersWithDefaults(headers),
-        response -> {
+    return post(okapiURL + "/authn/login", tenant, payload.encode(), combineHeadersWithDefaults(headers))
+        .map(response -> {
           if (response.statusCode() == 201) {
             logger.info("Successfully logged into FOLIO");
             String token = response.getHeader(X_OKAPI_TOKEN);
             setToken(token);
-            future.complete(token);
+            return token;
           } else {
             logger.warn("Failed to log into FOLIO: ({}) {}",
                 () -> response.statusCode(),
                 () -> response.bodyAsString());
-            future.complete(null);
+            return null;
           }
-        },
-        cause -> {
-          logger.error("Exception during login: " + cause.getMessage());
-          future.completeExceptionally(cause);
-        });
-    return future;
+        })
+        .onFailure(cause -> logger.error("Exception during login: " + cause.getMessage(), cause));
   }
 
   public CompletableFuture<Boolean> healthy() {
-    VertxCompletableFuture<Boolean> future = new VertxCompletableFuture<>(vertx);
-    get(
-        okapiURL + "/_/proxy/health",
-        tenant, response -> {
+    return health().toCompletionStage().toCompletableFuture();
+  }
+
+  public Future<Boolean> health() {
+    return get(okapiURL + "/_/proxy/health", tenant, null)
+        .map(response -> {
           int status = response.statusCode();
           if (status == 200) {
-            future.complete(true);
-          } else {
-            logger.error("OKAPI is unhealthy! status: {} body: {}",
-                () -> status, response::bodyAsString);
-            future.complete(false);
+            return true;
           }
-        },
-        t -> {
-          logger.error("Exception checking OKAPI's health: " + t.getMessage());
-          future.complete(false);
+          logger.error("OKAPI is unhealthy! status: {} body: {}",
+              () -> status, response::bodyAsString);
+          return false;
+        })
+        .otherwise(t -> {
+          logger.error("Exception checking OKAPI's health: " + t.getMessage(), t);
+          return false;
         });
-    return future;
   }
 
   public String getToken() {

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -83,7 +83,7 @@ public class MockOkapi {
         logger.warn("Invalid value specified for " + X_DURATION + " sleeping default request timeout instead");
       }
 
-      logger.info("Waiting for " + dur + " ms before continuing");
+      logger.info("Waiting for {} ms before continuing", dur);
       vertx.setTimer(dur, x -> ctx.next());
     } else {
       ctx.next();

--- a/src/test/java/org/folio/edge/core/InstitutionalUserHelperTest.java
+++ b/src/test/java/org/folio/edge/core/InstitutionalUserHelperTest.java
@@ -1,0 +1,36 @@
+package org.folio.edge.core;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.Future;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.edge.core.security.SecureStore;
+import org.folio.edge.core.utils.OkapiClient;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+@RunWith(VertxUnitRunner.class)
+public class InstitutionalUserHelperTest {
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Test
+  public void testWithoutCache(TestContext context) {
+    var secureStore = mock(SecureStore.class);
+    when(secureStore.get(any(), any(), any(), eq("name"))).thenReturn(Future.succeededFuture("pass"));
+    var okapiClient = mock(OkapiClient.class);
+    when(okapiClient.doLogin(eq("name"), eq("pass"))).thenReturn(Future.succeededFuture("tok"));
+    var institutionalUserHelper = new InstitutionalUserHelper(secureStore);
+    institutionalUserHelper.fetchToken(okapiClient, null, null, "name")
+    .onComplete(context.asyncAssertSuccess(result -> assertThat(result, is("tok"))));
+  }
+
+}

--- a/src/test/java/org/folio/edge/core/InstitutionalUserHelperTest.java
+++ b/src/test/java/org/folio/edge/core/InstitutionalUserHelperTest.java
@@ -27,7 +27,7 @@ public class InstitutionalUserHelperTest {
     var secureStore = mock(SecureStore.class);
     when(secureStore.get(any(), any(), any(), eq("name"))).thenReturn(Future.succeededFuture("pass"));
     var okapiClient = mock(OkapiClient.class);
-    when(okapiClient.doLogin(eq("name"), eq("pass"))).thenReturn(Future.succeededFuture("tok"));
+    when(okapiClient.doLogin("name", "pass")).thenReturn(Future.succeededFuture("tok"));
     var institutionalUserHelper = new InstitutionalUserHelper(secureStore);
     institutionalUserHelper.fetchToken(okapiClient, null, null, "name")
     .onComplete(context.asyncAssertSuccess(result -> assertThat(result, is("tok"))));


### PR DESCRIPTION
Remove any usage of the

me.escoffier.vertx:vertx-completable-future = https://github.com/cescoffier/vertx-completable-future

library because it is no longer maintained and doesn't work with Vert.x 4.

For details see https://issues.folio.org/browse/FOLREL-547