### PR TITLE
EDGCOMMON-47: Fix behavior when tenant header is present in a request

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -257,20 +257,20 @@ public class OkapiClient {
   }
 
   protected MultiMap combineHeadersWithDefaults(MultiMap headers) {
-    MultiMap combined = null;
+    if (headers == null || headers.isEmpty()) {
+      return defaultHeaders;
+    }
 
-    if (headers != null) {
-      headers.remove(HEADER_API_KEY);
-      if (headers.size() > 0) {
-        combined = MultiMap.caseInsensitiveMultiMap();
-        combined.addAll(headers);
-        for (Entry<String, String> entry : defaultHeaders.entries()) {
-          if (!combined.contains(entry.getKey())) {
-            combined.set(entry.getKey(), entry.getValue());
-          }
-        }
+    MultiMap combined = MultiMap.caseInsensitiveMultiMap();
+    combined.addAll(headers);
+    // remove from combined because headers might not be case insensitive
+    combined.remove(HEADER_API_KEY);
+    combined.remove(X_OKAPI_TENANT);  // don't allow to overwrite: https://issues.folio.org/browse/EDGCOMMON-47
+    for (Entry<String, String> entry : defaultHeaders.entries()) {
+      if (!combined.contains(entry.getKey())) {
+        combined.set(entry.getKey(), entry.getValue());
       }
     }
-    return combined != null ? combined : defaultHeaders;
+    return combined;
   }
 }

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -2,10 +2,13 @@ package org.folio.edge.core.utils;
 
 import static org.folio.edge.core.Constants.APPLICATION_JSON;
 import static org.folio.edge.core.Constants.HEADER_API_KEY;
+import static org.folio.edge.core.Constants.X_OKAPI_TENANT;
 import static org.folio.edge.core.Constants.X_OKAPI_TOKEN;
 import static org.folio.edge.core.utils.test.MockOkapi.MOCK_TOKEN;
 import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
 import static org.folio.edge.core.utils.test.MockOkapi.X_ECHO_STATUS;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -294,6 +297,15 @@ public class OkapiClientTest {
           async.complete();
         },
         t -> context.fail(t));
+  }
+
+  @Test
+  public void testWrongTenantHeader(TestContext context) {
+    var headers = MultiMap.caseInsensitiveMultiMap().add(X_OKAPI_TENANT, "foo");
+    client.get(String.format("http://localhost:%s/echo", mockOkapi.okapiPort), "bar", headers)
+    .onComplete(context.asyncAssertSuccess(response -> {
+      assertThat(response.getHeader(X_OKAPI_TENANT), is("diku"));
+    }));
   }
 
   @Test


### PR DESCRIPTION
Fix the bug where the X-Okapi-Tenant header in the request overwrites
the configured X-Okapi-Tenant header in the response.