### PR TITLE
EDGCOMMON-51: Futurize MockOkapi for Junit 5 and .compose

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -16,7 +16,6 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
@@ -46,7 +45,7 @@ public class MockOkapi {
     this.knownTenants = knownTenants == null ? new ArrayList<>() : knownTenants;
   }
 
-  public Future<Void> close(TestContext context) {
+  public Future<Void> close() {
     return vertx.close()
         .onSuccess(x -> logger.info("Successfully shut down mock OKAPI server"))
         .onFailure(e -> logger.error("Failed to shut down mock OKAPI server", e));

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -115,7 +115,7 @@ public class MockOkapi {
     HttpServer server = vertx.createHttpServer();
     return server.requestHandler(defineRoutes()).listen(okapiPort)
         .onFailure(e -> logger.warn(e.getMessage(), e))
-        .onSuccess(httpServer -> this.httpServer = httpServer);
+        .onSuccess(anHttpServer -> httpServer = anHttpServer);
   }
 
   public void durationHandler(RoutingContext ctx) {

--- a/src/test/java/org/folio/edge/core/EdgeVerticleHttpTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleHttpTest.java
@@ -12,7 +12,6 @@ import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
 import static org.folio.edge.core.utils.test.MockOkapi.X_ECHO_STATUS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -44,7 +43,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.ext.web.Router;
@@ -96,19 +94,12 @@ public class EdgeVerticleHttpTest {
   @AfterClass
   public static void tearDownOnce(TestContext context) {
     logger.info("Shutting down server");
-    final Async async = context.async();
-    vertx.close(res -> {
-      if (res.failed()) {
-        logger.error("Failed to shut down edge-common server", res.cause());
-        fail(res.cause().getMessage());
-      } else {
-        logger.info("Successfully shut down edge-common server");
-      }
 
-      logger.info("Shutting down mock Okapi");
-      mockOkapi.close(context);
-      async.complete();
-    });
+    vertx.close()
+    .onSuccess(x -> logger.info("Successfully shut down edge-common server"))
+    .compose(x -> mockOkapi.close())
+    .onSuccess(x -> logger.info("Successfully shut down mock Okapi"))
+    .onComplete(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/EdgeVerticleHttpTest.java
+++ b/src/test/java/org/folio/edge/core/EdgeVerticleHttpTest.java
@@ -41,7 +41,6 @@ import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
-import io.vertx.core.VertxException;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
@@ -74,7 +73,8 @@ public class EdgeVerticleHttpTest {
     knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
 
     mockOkapi = spy(new MockOkapi(okapiPort, knownTenants));
-    mockOkapi.start(context);
+    mockOkapi.start()
+    .onComplete(context.asyncAssertSuccess());
 
     vertx = Vertx.vertx();
 

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -56,7 +56,8 @@ public class ResponseCompressionTest {
         knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
 
         mockOkapi = spy(new MockOkapi(okapiPort, knownTenants));
-        mockOkapi.start(context);
+        mockOkapi.start()
+        .onComplete(context.asyncAssertSuccess());
 
         vertx = Vertx.vertx();
 

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -8,7 +8,6 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.logging.log4j.LogManager;
@@ -33,7 +32,6 @@ import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
 import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 
 @RunWith(VertxUnitRunner.class)
@@ -55,11 +53,11 @@ public class ResponseCompressionTest {
         List<String> knownTenants = new ArrayList<>();
         knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
 
-        mockOkapi = spy(new MockOkapi(okapiPort, knownTenants));
+        vertx = Vertx.vertx();
+
+        mockOkapi = spy(new MockOkapi(vertx, okapiPort, knownTenants));
         mockOkapi.start()
         .onComplete(context.asyncAssertSuccess());
-
-        vertx = Vertx.vertx();
 
         JsonObject jo = new JsonObject()
                 .put(SYS_PORT, serverPort)
@@ -79,22 +77,10 @@ public class ResponseCompressionTest {
 
     @AfterClass
     public static void tearDownOnce(TestContext context) {
-        final Async async = context.async();
         logger.info("Shutting down server");
-        vertx.close(res -> {
-            if (res.failed()) {
-                logger.error("Failed to shut down edge-common server", res.cause());
-                fail(res.cause().getMessage());
-            } else {
-                logger.info("Successfully shut down edge-common server");
-            }
-
-            logger.info("Shutting down mock Okapi");
-            mockOkapi.close(context);
-            async.complete();
-        });
+        vertx.close()  // this automatically shuts down mockOkapi
+        .onComplete(context.asyncAssertSuccess());
     }
-
 
     @Test
     public void testResponseCompression(TestContext context) {

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -65,7 +65,8 @@ public class OkapiClientTest {
 
   @After
   public void tearDown(TestContext context) {
-    mockOkapi.close(context);
+    mockOkapi.close()
+    .onComplete(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
+++ b/src/test/java/org/folio/edge/core/utils/OkapiClientTest.java
@@ -56,7 +56,8 @@ public class OkapiClientTest {
     knownTenants.add(tenant);
 
     mockOkapi = new MockOkapi(okapiPort, knownTenants);
-    mockOkapi.start(context);
+    mockOkapi.start()
+    .onComplete(context.asyncAssertSuccess());
 
     ocf = new OkapiClientFactory(Vertx.vertx(), "http://localhost:" + okapiPort, reqTimeout);
     client = ocf.getOkapiClient(tenant);

--- a/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
@@ -60,7 +60,8 @@ public class MockOkapiTest {
 
   @AfterClass
   public static void tearDown(TestContext context) {
-    mockOkapi.close(context);
+    mockOkapi.close()
+    .onComplete(context.asyncAssertSuccess());
   }
 
   @Test

--- a/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
@@ -47,7 +47,8 @@ public class MockOkapiTest {
     knownTenants.add(tenant);
 
     mockOkapi = new MockOkapi(okapiPort, knownTenants);
-    mockOkapi.start(context);
+    mockOkapi.start()
+    .onComplete(context.asyncAssertSuccess());
 
     RestAssured.baseURI = "http://localhost:" + okapiPort;
     RestAssured.port = okapiPort;

--- a/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
+++ b/src/test/java/org/folio/edge/core/utils/test/MockOkapiTest.java
@@ -11,6 +11,8 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,14 +21,18 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
 import io.restassured.config.EncoderConfig;
 import io.restassured.response.Response;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
@@ -38,6 +44,9 @@ public class MockOkapiTest {
   private static final String tenant = "diku";
 
   private static MockOkapi mockOkapi;
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(10);
 
   @BeforeClass
   public static void setUp(TestContext context) {
@@ -228,5 +237,45 @@ public class MockOkapiTest {
       .response();
 
     assertEquals("", resp.body().asString());
+  }
+
+  private Future<Void> assertGet200(String uri) {
+    return Vertx.currentContext().executeBlocking(promise -> {
+      try {
+        RestAssured
+        .get(new URI(uri))
+        .then()
+        .statusCode(200);
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+      promise.complete();
+    });
+  }
+
+  @Test
+  public void testVertxClose(TestContext context) {
+    int port2 = TestUtils.getPort();
+    var vertx2 = Vertx.vertx();
+    var okapi2 = new MockOkapi(vertx2, port2, List.of());
+
+    okapi2.close()
+    .onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testHttpClose(TestContext context) {
+    int port2 = TestUtils.getPort();
+    var uri = "http://localhost:" + port2 + "/_/proxy/health";
+    var vertx2 = Vertx.vertx();
+    var okapi2 = new MockOkapi(vertx2, port2, List.of());
+
+    okapi2.start()
+    .compose(x -> assertGet200(uri))
+    .compose(x -> okapi2.close())
+    .compose(x -> vertx2.createHttpClient().close())  // vertx2 still works
+    .onComplete(context.asyncAssertSuccess())
+    .compose(x -> assertGet200(uri))
+    .onComplete(context.asyncAssertFailure());
   }
 }


### PR DESCRIPTION
Steps to Reproduce:

https://github.com/folio-org/edge-oai-pmh/blob/3ccabce4dd9a81dc4f7ce792956c4b4aac3a6496/src/test/java/org/folio/edge/oaipmh/utils/OaiPmhMockOkapi.java

Expected Results:

MockOkapi can be used with JUnit 5 and Junit 4.

MockOkapi#start and MockOkapi#close allow to .compose multiple Futures:

mockOkapi.start()
.compose(x -> startFooService())
.onComplete(context.asyncAssertSuccess());

Actual Results:

If pom.xml doesn't add the Junit 4 vertx-unit dependency the test will fail because MockOkapi requires Junit 4 vertx-unit in start and close method:

public void start(TestContext context)

public void close(TestContext context)

Cannot use a JUnit 5 VertxTestContext with start or close.

Neither start nor close allow to compose multiple Futures.

Solution:

Futurize MockOkapi#start and MockOkapi#close so that they can be used with Junit 5 and with .compose.