### PR TITLE
FOLIO-3231 Remove old config API doc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 buildMvn {
   publishModDescriptor = 'no'
-  publishAPI = 'no'
   mvnDeploy = 'yes'
   buildNode = 'jenkins-agent-java11'
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # edge-common
 
-Copyright (C) 2018-2021 The Open Library Foundation
+Copyright (C) 2018-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The Jenkinsfile settings were 'false' (which is the default) so not being used.

If needed in the future, then use [api-lint](https://dev.folio.org/guides/api-lint/) and [api-doc](https://dev.folio.org/guides/api-doc/). Those tools apply to both RAML and OpenAPI (OAS).