### PR TITLE
Code cleanup in EdgeVerticleCore

### DIFF
--- a/src/main/java/org/folio/edge/core/EdgeVerticleCore.java
+++ b/src/main/java/org/folio/edge/core/EdgeVerticleCore.java
@@ -93,7 +93,7 @@ public class EdgeVerticleCore extends AbstractVerticle {
 
     try (InputStream in = createInputStream(secureStorePropFile)) {
       secureStoreProps.load(in);
-      logger.info("Successfully loaded properties from: " + secureStorePropFile);
+      logger.info("Successfully loaded properties from: {}", secureStorePropFile);
       return Future.succeededFuture(secureStoreProps);
     } catch (Exception e) {
       Exception ex = new IOException("Failed to load secure store properties: " + e.getMessage(), e);


### PR DESCRIPTION
Test against ConnectException, not against
error message "Connection refused" that is
"Verbindungsaufbau abgelehnt" in German locale.

In getProperties reduce complexity: Extract code
into createInputStream to avoid nested try clauses,
use guard clause to avoid if clause nesting.

Fix log level.

Replace compose by map in initializeSecureStore Future.