### PR TITLE
EDGCOMMON-52: Enable "Accept-Encoding: deflate, gzip" by default

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/OkapiClient.java
+++ b/src/main/java/org/folio/edge/core/utils/OkapiClient.java
@@ -61,6 +61,7 @@ public class OkapiClient {
   }
 
   protected void initDefaultHeaders() {
+    defaultHeaders.add(HttpHeaders.ACCEPT_ENCODING, HttpHeaders.DEFLATE_GZIP);
     defaultHeaders.add(HttpHeaders.ACCEPT.toString(), JSON_OR_TEXT);
     defaultHeaders.add(HttpHeaders.CONTENT_TYPE.toString(), APPLICATION_JSON);
     defaultHeaders.add(X_OKAPI_TENANT, tenant);

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -15,6 +15,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -112,7 +113,8 @@ public class MockOkapi {
   public Future<HttpServer> start() {
 
     // Setup Mock Okapi...
-    HttpServer server = vertx.createHttpServer();
+    var options = new HttpServerOptions().setCompressionSupported(true);
+    HttpServer server = vertx.createHttpServer(options);
     return server.requestHandler(defineRoutes()).listen(okapiPort)
         .onFailure(e -> logger.warn(e.getMessage(), e))
         .onSuccess(anHttpServer -> httpServer = anHttpServer);

--- a/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
+++ b/src/test/java/org/folio/edge/core/ResponseCompressionTest.java
@@ -1,15 +1,25 @@
 package org.folio.edge.core;
 
+import static io.restassured.config.DecoderConfig.decoderConfig;
+import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
+import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
+import static org.folio.edge.core.Constants.SYS_PORT;
+import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
+import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
+import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
+import static org.folio.edge.core.Constants.TEXT_PLAIN;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.spy;
+
 import io.restassured.RestAssured;
-import io.restassured.config.DecoderConfig;
+import io.restassured.config.DecoderConfig.ContentDecoder;
 import io.restassured.http.Header;
-import io.restassured.response.Response;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.ApiKeyUtils;
@@ -23,111 +33,112 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.restassured.config.DecoderConfig.decoderConfig;
-import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
-import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
-import static org.folio.edge.core.Constants.SYS_PORT;
-import static org.folio.edge.core.Constants.SYS_REQUEST_TIMEOUT_MS;
-import static org.folio.edge.core.Constants.SYS_RESPONSE_COMPRESSION;
-import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
-import static org.folio.edge.core.Constants.TEXT_PLAIN;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.spy;
-
 @RunWith(VertxUnitRunner.class)
 public class ResponseCompressionTest {
 
-    private static final Logger logger = LogManager.getLogger(ResponseCompressionTest.class);
+  private static final Logger logger = LogManager.getLogger(ResponseCompressionTest.class);
 
-    private static final String apiKey = "eyJzIjoiZ0szc0RWZ3labCIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==";
-    private static final long requestTimeoutMs = 10000L;
+  private static final String apiKey = "eyJzIjoiZ0szc0RWZ3labCIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==";
+  private static final long requestTimeoutMs = 10000L;
 
-    private static Vertx vertx;
-    private static MockOkapi mockOkapi;
+  private static Vertx vertx;
+  private static MockOkapi mockOkapi;
 
-    @BeforeClass
-    public static void setUpOnce(TestContext context) throws Exception {
-        int okapiPort = TestUtils.getPort();
-        int serverPort = TestUtils.getPort();
+  @BeforeClass
+  public static void setUpOnce(TestContext context) throws Exception {
+    int okapiPort = TestUtils.getPort();
+    int serverPort = TestUtils.getPort();
 
-        List<String> knownTenants = new ArrayList<>();
-        knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
+    List<String> knownTenants = new ArrayList<>();
+    knownTenants.add(ApiKeyUtils.parseApiKey(apiKey).tenantId);
 
-        vertx = Vertx.vertx();
+    vertx = Vertx.vertx();
 
-        mockOkapi = spy(new MockOkapi(vertx, okapiPort, knownTenants));
-        mockOkapi.start()
-        .onComplete(context.asyncAssertSuccess());
+    mockOkapi = spy(new MockOkapi(vertx, okapiPort, knownTenants));
+    mockOkapi.start()
+    .onComplete(context.asyncAssertSuccess());
 
-        JsonObject jo = new JsonObject()
-                .put(SYS_PORT, serverPort)
-                .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
-                .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
-                .put(SYS_LOG_LEVEL, "TRACE")
-                .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
-                .put(SYS_RESPONSE_COMPRESSION, true);
+    JsonObject jo = new JsonObject()
+            .put(SYS_PORT, serverPort)
+            .put(SYS_OKAPI_URL, "http://localhost:" + okapiPort)
+            .put(SYS_SECURE_STORE_PROP_FILE, "src/main/resources/ephemeral.properties")
+            .put(SYS_LOG_LEVEL, "TRACE")
+            .put(SYS_REQUEST_TIMEOUT_MS, requestTimeoutMs)
+            .put(SYS_RESPONSE_COMPRESSION, true);
 
-        final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
-        vertx.deployVerticle(EdgeVerticleHttpTest.TestVerticleHttp.class.getName(), opt, context.asyncAssertSuccess());
+    final DeploymentOptions opt = new DeploymentOptions().setConfig(jo);
+    vertx.deployVerticle(EdgeVerticleHttpTest.TestVerticleHttp.class.getName(), opt, context.asyncAssertSuccess());
 
-        RestAssured.baseURI = "http://localhost:" + serverPort;
-        RestAssured.port = serverPort;
-        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
-    }
+    RestAssured.baseURI = "http://localhost:" + serverPort;
+    RestAssured.port = serverPort;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+  }
 
-    @AfterClass
-    public static void tearDownOnce(TestContext context) {
-        logger.info("Shutting down server");
-        vertx.close()  // this automatically shuts down mockOkapi
-        .onComplete(context.asyncAssertSuccess());
-    }
+  @AfterClass
+  public static void tearDownOnce(TestContext context) {
+    logger.info("Shutting down server");
+    vertx.close()  // this automatically shuts down mockOkapi
+    .onComplete(context.asyncAssertSuccess());
+  }
 
-    @Test
-    public void testResponseCompression(TestContext context) {
-        logger.info("=== Test response compression (Accept-Encoding: gzip / Accept-Encoding: deflate)  ===");
+  @Test
+  public void testResponseGzip() {
+    logger.info("=== Test response GZip compression ===");
 
-        for (DecoderConfig.ContentDecoder type : DecoderConfig.ContentDecoder.values()) {
-            final Response resp = RestAssured.given()
-                    .config(RestAssured.config().decoderConfig(decoderConfig().contentDecoders(type)))
-                    .get("/admin/health")
-                    .then()
-                    .contentType(TEXT_PLAIN)
-                    .statusCode(200)
-                    .header(HttpHeaders.CONTENT_ENCODING.toString(), type.name().toLowerCase())
-                    .extract()
-                    .response();
-            assertEquals("\"OK\"", resp.body().asString());
-        }
-    }
+    RestAssured.given()
+      .config(RestAssured.config().decoderConfig(decoderConfig().contentDecoders(ContentDecoder.GZIP)))
+    .when()
+       .get("/admin/health")
+    .then()
+       .contentType(TEXT_PLAIN)
+       .statusCode(200)
+       .header(HttpHeaders.CONTENT_ENCODING, "gzip")
+       .body(is("\"OK\""));
+  }
 
-    @Test
-    public void testResponseNoCompressionHeaderInstance(TestContext context) {
-        logger.info("=== Test no compression (Accept-Encoding: instance) ===");
+  @Test
+  public void testResponseDeflate() {
+    logger.info("=== Test response GZip compression ===");
 
-        final Response resp = RestAssured.given()
-                .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
-                .header(new Header(org.apache.http.HttpHeaders.ACCEPT_ENCODING, "instance"))
-                .get("/admin/health")
-                .then()
-                .contentType(TEXT_PLAIN)
-                .statusCode(200)
-                .extract()
-                .response();
-        assertEquals("\"OK\"", resp.body().asString());
-    }
+    RestAssured.given()
+      .config(RestAssured.config().decoderConfig(decoderConfig().contentDecoders(ContentDecoder.DEFLATE)))
+    .when()
+       .get("/admin/health")
+    .then()
+       .contentType(TEXT_PLAIN)
+       .statusCode(200)
+       .header(HttpHeaders.CONTENT_ENCODING, "deflate")
+       .body(is("\"OK\""));
+  }
 
-    @Test
-    public void testResponseNoCompressionWithoutAcceptEncoding(TestContext context) {
-        logger.info("=== Test no compression (without Accept-Encoding header) ===");
+  @Test
+  public void testResponseNoCompressionHeaderInstance(TestContext context) {
+    logger.info("=== Test no compression (Accept-Encoding: instance) ===");
 
-        final Response resp = RestAssured.given()
-                .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
-                .get("/admin/health")
-                .then()
-                .contentType(TEXT_PLAIN)
-                .statusCode(200)
-                .extract()
-                .response();
-        assertEquals("\"OK\"", resp.body().asString());
-    }
+    RestAssured.given()
+        .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
+        .header(new Header(org.apache.http.HttpHeaders.ACCEPT_ENCODING, "instance"))
+      .when()
+        .get("/admin/health")
+      .then()
+        .contentType(TEXT_PLAIN)
+        .statusCode(200)
+        .header(HttpHeaders.CONTENT_ENCODING, (String) null)
+        .body(is("\"OK\""));
+  }
+
+  @Test
+  public void testResponseNoCompressionWithoutAcceptEncoding(TestContext context) {
+    logger.info("=== Test no compression (without Accept-Encoding header) ===");
+
+    RestAssured.given()
+      .config(RestAssured.config().decoderConfig(decoderConfig().noContentDecoders()))
+    .when()
+      .get("/admin/health")
+    .then()
+      .contentType(TEXT_PLAIN)
+      .statusCode(200)
+      .header(HttpHeaders.CONTENT_ENCODING, (String) null)
+      .body(is("\"OK\""));
+  }
 }


### PR DESCRIPTION
Enable HTTP compression support (deflate, gzip) for the response from mod-x to edge-x.

There are two completely independent HTTP connections:

a) external client <-> edge-x, edge-x uses compression if external client sends "Accept-Encoding" HTTP header.
b) edge-x <-> mod-x, mod-x uses compression if edge-x sends "Accept-Encoding" HTTP header.

The two HTTP connections may use different compression algorithms, as set in the "Accept-Encoding" header.

This pull request is about b).

It is wrong if edge-x passes on the Accept-Encoding header from external client to mod-x. This needs to be fixed in the edge-x modules.