### PR TITLE
EDGCOMMON-53: Deprecate X-Duration, provide setDelay, fix timeout msg

### DIFF
--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -82,13 +82,23 @@ public class Handler {
         action.apply(client, params);
       })
       .exceptionally(t -> {
-        if (t instanceof TimeoutException) {
+        if (isTimeoutException(t)) {
           requestTimeout(ctx, t.getMessage());
         } else {
           accessDenied(ctx, t.getMessage());
         }
         return null;
       });
+  }
+
+  protected static boolean isTimeoutException(Throwable t) {
+    if (t == null) {
+      return false;
+    }
+    if (t instanceof TimeoutException) {
+      return true;
+    }
+    return isTimeoutException(t.getCause());
   }
 
   protected void handleProxyResponse(RoutingContext ctx, HttpResponse<Buffer> resp) {
@@ -105,7 +115,7 @@ public class Handler {
 
   protected void handleProxyException(RoutingContext ctx, Throwable t) {
     logger.error("Exception calling OKAPI", t);
-    if (t instanceof TimeoutException) {
+    if (isTimeoutException(t)) {
       requestTimeout(ctx, t.getMessage());
     } else {
       internalServerError(ctx, t.getMessage());

--- a/src/main/java/org/folio/edge/core/Handler.java
+++ b/src/main/java/org/folio/edge/core/Handler.java
@@ -92,13 +92,14 @@ public class Handler {
   }
 
   protected static boolean isTimeoutException(Throwable t) {
-    if (t == null) {
-      return false;
-    }
     if (t instanceof TimeoutException) {
       return true;
     }
-    return isTimeoutException(t.getCause());
+    var cause = t.getCause();
+    if (cause == null) {
+      return false;
+    }
+    return isTimeoutException(cause);
   }
 
   protected void handleProxyResponse(RoutingContext ctx, HttpResponse<Buffer> resp) {

--- a/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
+++ b/src/main/java/org/folio/edge/core/utils/test/MockOkapi.java
@@ -33,13 +33,13 @@ public class MockOkapi {
    * @deprecated Use {@link #setDelay(long)} instead. For security an edge module should not
    *     pass any headers from the external client to the back-end module unless strictly needed.
    */
-  @Deprecated
+  @Deprecated(since="4.4.0", forRemoval=true)
   public static final String X_DURATION = "X-Duration";
   /**
    * @deprecated Use proper mocking instead. For security an edge module should not
    *     pass any headers from the external client to the back-end module unless strictly needed.
    */
-  @Deprecated
+  @Deprecated(since="4.4.0", forRemoval=true)
   public static final String X_ECHO_STATUS = "X-Echo-Status";
 
   public static final String MOCK_TOKEN = UUID.randomUUID().toString();


### PR DESCRIPTION
Deprecate MockOkapi's X-Duration header. For security an edge module
should not pass any headers from the external client to the back-end
module unless strictly needed.

Provide MockOkapi.setDelay as a replacement for X-Duration.

Fix timeout reporting (HTTP 408 response code) by also checking
if Throwable.getCause() is instanceof TimeoutException.