### PR TITLE
EDGCOMMON-54: Vert.x 4.3.3 fixing disabled SSL in 4.3.0/4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.1</version>
+        <version>4.3.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Vert.x 4.3.0 and 4.3.1 have this regression: They disable SSL in WebClient.

Vert.x >= 4.3.2 has a fix.

https://issues.folio.org/browse/EDGCOMMON-54