### PR TITLE
EDGCOMMON-70: Failure to find maven-deploy-plugin:jar:3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>deploy</id>


### PR DESCRIPTION
Wrong maven-deploy-plugin version: 3.6.0

Right version: 3.1.1