### PR TITLE
EDGCOMMON-72: Vert.x 4.4.6, Netty 4.1.100.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.4.5</version>
+        <version>4.4.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.4.5 to 4.4.6. This indirectly upgrades Netty from 4.1.97.Final to 4.1.100.Final fixing HTTP/2 Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2023-44487