### PR TITLE
EDGCOMMON-74: aws-java-sdk-ssm 1.12.645 removing ion-java 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ssm</artifactId>
-      <version>1.12.562</version>
+      <version>1.12.645</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/EDGCOMMON-74

Upgrade aws-java-sdk-ssm from 1.12.562 to 1.12.645. This removes the dependency and usage of software.amazon.ion:ion-java@1.0.2 that has an Allocation of Resources Without Limits or Throttling vulnerability:

https://nvd.nist.gov/vuln/detail/CVE-2024-21634
https://github.com/aws/aws-sdk-java/issues/3077#issuecomment-1896650670