### PR TITLE
EDGCOMMON-80: Vert.x 4.5.7, Netty 4.1.108.Final fixing CVE-2024-29025

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.5.4</version>
+        <version>4.5.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vertx from 4.5.4 to 4.5.7.

This indirectly upgrades Netty from 4.1.107.Final to Netty 4.1.108.Final fixing netty-codec-http form POST OOM (Allocation of Resources Without Limits or Throttling):
https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v
https://nvd.nist.gov/vuln/detail/CVE-2024-29025