### PR TITLE
Release v4.7.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+
+## 4.7.0 2024-05-23
+[Full Changelog](https://github.com/folio-org/edge-common/compare/v4.6.0...v4.7.0)
+
+## Stories
+* [EDGCOMMON-80](https://folio-org.atlassian.net/browse/EDGCOMMON-80) - Vert.x 4.5.7, Netty 4.1.108.Final fixing form post OOM CVE-2024-29025 
+* [EDGCOMMON-78](https://folio-org.atlassian.net/browse/EDGCOMMON-78) - Enhance HTTP Endpoint Security with TLS and FIPS-140-2 Compliant Cryptography
+* [EDGCOMMON-77](https://folio-org.atlassian.net/browse/EDGCOMMON-77) - Support HTTPS in OkapiClient, SSL
+
+
 ## 4.6.0 2024-03-11
 
  * [EDGCOMMON-75](https://folio-org.atlassian.net/browse/EDGCOMMON-75) Quesnelia dep upgrades: Vert.x 4.5.4, aws 1.12.671, vault 6.2.0, … 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>4.7.0</version>
+  <version>4.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-common.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-common.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-common.git</developerConnection>
-    <tag>v4.7.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-common</artifactId>
-  <version>4.7.0-SNAPSHOT</version>
+  <version>4.7.0</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Common</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-common.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-common.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-common.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v4.7.0</tag>
   </scm>
 
   <licenses>


### PR DESCRIPTION
Releasing these stories
## Stories
* [EDGCOMMON-80](https://folio-org.atlassian.net/browse/EDGCOMMON-80) - Vert.x 4.5.7, Netty 4.1.108.Final fixing form post OOM CVE-2024-29025 
* [EDGCOMMON-78](https://folio-org.atlassian.net/browse/EDGCOMMON-78) - Enhance HTTP Endpoint Security with TLS and FIPS-140-2 Compliant Cryptography
* [EDGCOMMON-77](https://folio-org.atlassian.net/browse/EDGCOMMON-77) - Support HTTPS in OkapiClient, SSL