### PR TITLE
EDGCOMMON-91: ApiKeyUtils doesn't use z when generating the salt

### DIFF
--- a/src/main/java/org/folio/edge/core/utils/ApiKeyUtils.java
+++ b/src/main/java/org/folio/edge/core/utils/ApiKeyUtils.java
@@ -13,7 +13,7 @@ import io.vertx.core.json.JsonObject;
 
 public class ApiKeyUtils {
 
-  public static final String ALPHANUMERIC = "0123456789abcdefghijklmnopqrstuvwxyABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  public static final String ALPHANUMERIC = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
   public static final Random RANDOM = new SecureRandom();
   public static final int DEFAULT_SALT_LEN = 10;
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGCOMMON-91

Add z to set of alphanumeric characters.